### PR TITLE
Drag words back to the word bank area

### DIFF
--- a/src/components/WordBankArea/index.js
+++ b/src/components/WordBankArea/index.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { DropTarget } from 'react-dnd';
+// constants
+import ItemTypes from '../ItemTypes';
 // components
 import WordBankItem from '../WordBankItem';
 
 const WordBankArea = ({
   contextIdReducer,
-  wordAlignmentReducer
+  wordAlignmentReducer,
+  connectDropTarget,
+  isOver
 }) => {
   if (contextIdReducer.contextId) {
     const { chapter, verse } = contextIdReducer.contextId.reference;
@@ -15,9 +20,11 @@ const WordBankArea = ({
       wordBank = wordAlignmentReducer.alignmentData[chapter][verse].wordBank;
     }
 
-    return (
+    return connectDropTarget(
       <div style={{ flex: 0.2, width: '100%', backgroundColor: '#DCDCDC', overflowY: 'auto', padding: '5px 8px 5px 5px' }}>
         {
+          isOver ? <div style={{ border: '3px dashed #44C6FF', height: '100%', width: '100%' }}></div>
+          : 
           wordBank.map((metadata, index) => (
             <WordBankItem
               key={index}
@@ -35,7 +42,26 @@ const WordBankArea = ({
 
 WordBankArea.propTypes = {
   contextIdReducer: PropTypes.object.isRequired,
-  wordAlignmentReducer: PropTypes.object.isRequired
+  wordAlignmentReducer: PropTypes.object.isRequired,
+  connectDropTarget: PropTypes.func.isRequired
 };
 
-export default WordBankArea;
+const wordBankAreaItemAction = {
+  drop(props, monitor) {
+    props.actions.moveBackToWordBank(monitor.getItem());
+  }
+};
+
+const collect = (connect, monitor) => {
+  return {
+    connectDropTarget: connect.dropTarget(),
+    isOver: monitor.isOver(),
+    canDrop: monitor.canDrop()
+  };
+};
+
+export default DropTarget(
+  ItemTypes.BOTTOM_WORD, // itemType
+  wordBankAreaItemAction,
+  collect
+)(WordBankArea);


### PR DESCRIPTION
- Made the word bank area a drop zone to allow wordBankItems to be moved back to it.
- Added actions that perform the word bank item moving

# Test
- Test with https://github.com/unfoldingWord-dev/translationCore/pull/2844
- Try dragging words from the greek area back to the word bank area.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-alignment-tool/5)
<!-- Reviewable:end -->
