### PR TITLE
Merging TopWords and aligned bottom words

### DIFF
--- a/src/components/DropBoxArea/index.js
+++ b/src/components/DropBoxArea/index.js
@@ -1,5 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+// constants
+import ItemTypes from '../ItemTypes';
 // components
 import DropBoxItem from '../DropBoxItem';
 
@@ -33,7 +35,19 @@ class DropBoxArea extends Component {
   }
 
   handleDrop(index, wordBankItem) {
-    this.props.actions.moveWordBankItemToAlignment(index, wordBankItem);
+    switch (wordBankItem.type) {
+      case ItemTypes.BOTTOM_WORD: {
+        this.props.actions.moveWordBankItemToAlignment(index, wordBankItem);
+        break;
+      }
+      case ItemTypes.TOP_WORD: {
+        // this.props.actions.moveTopWordToAlignment(index, wordBankItem);
+        break;
+      }
+      default: {
+        // Do nothing
+      }
+    }
   }
 }
 

--- a/src/components/DropBoxArea/index.js
+++ b/src/components/DropBoxArea/index.js
@@ -1,54 +1,58 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 // constants
 import ItemTypes from '../ItemTypes';
 // components
 import DropBoxItem from '../DropBoxItem';
 
-const DropBoxArea = ({
-  actions,
-  resourcesReducer,
-  wordAlignmentReducer,
-  contextIdReducer: {
-    contextId
-  }
-}) => {
-  if (!contextId) {
+class DropBoxArea extends Component {
+  render() {
+    const {
+      actions,
+      resourcesReducer,
+      wordAlignmentReducer,
+      contextIdReducer: {
+        contextId
+      }
+    } = this.props;
+
+    if (!contextId) {
+      return <div />;
+    }
+    const { chapter, verse } = contextId.reference;
+    const alignments = wordAlignmentReducer.alignmentData[chapter][verse].alignments;
     return (
-      <div />
+      <div style={{ display: 'flex', flexWrap: 'wrap', height: '100%', backgroundColor: '#ffffff', padding: '0px 10px 50px', overflowY: 'auto' }}>
+        {
+          alignments.map((alignment, index) => {
+            return (
+              <DropBoxItem
+                key={index}
+                alignmentIndex={index}
+                bottomWords={alignment.bottomWords}
+                topWords={alignment.topWords}
+                onDrop={item => this.handleDrop(index, item)}
+                actions={actions}
+                resourcesReducer={resourcesReducer}
+              />
+            );
+          })
+        }
+      </div>
     );
   }
-  const { chapter, verse } = contextId.reference;
-  const alignments = wordAlignmentReducer.alignmentData[chapter][verse].alignments;
-  return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', height: '100%', backgroundColor: '#ffffff', padding: '0px 10px 50px', overflowY: 'auto' }}>
-      {
-        alignments.map((alignment, index) => {
-          return (
-            <DropBoxItem
-              key={index}
-              alignmentIndex={index}
-              bottomWords={alignment.bottomWords}
-              topWords={alignment.topWords}
-              onDrop={item => this.handleDrop(index, item)}
-              actions={actions}
-              resourcesReducer={resourcesReducer}
-            />
-          );
-        })
-      }
-    </div>
-  );
-};
 
-DropBoxArea.handleDrop = (index, wordBankItem) => {
-  if (wordBankItem.type === ItemTypes.BOTTOM_WORD) {
-    this.props.actions.moveWordBankItemToAlignment(index, wordBankItem);
+  handleDrop(index, wordBankItem) {
+    if (wordBankItem.type === ItemTypes.BOTTOM_WORD) {
+      this.props.actions.moveWordBankItemToAlignment(index, wordBankItem);
+    }
+    if (wordBankItem.type === ItemTypes.TOP_WORD) {
+      this.props.actions.mergeAlignments(wordBankItem.alignmentIndex, index);
+    }
   }
-  if (wordBankItem.type === ItemTypes.TOP_WORD) {
-    this.props.actions.mergeAlignments(wordBankItem.alignmentIndex, index);
-  }
-};
+}
+
+
 
 DropBoxArea.propTypes = {
   wordAlignmentReducer: PropTypes.object.isRequired,

--- a/src/components/DropBoxArea/index.js
+++ b/src/components/DropBoxArea/index.js
@@ -35,18 +35,11 @@ class DropBoxArea extends Component {
   }
 
   handleDrop(index, wordBankItem) {
-    switch (wordBankItem.type) {
-      case ItemTypes.BOTTOM_WORD: {
-        this.props.actions.moveWordBankItemToAlignment(index, wordBankItem);
-        break;
-      }
-      case ItemTypes.TOP_WORD: {
-        // this.props.actions.moveTopWordToAlignment(index, wordBankItem);
-        break;
-      }
-      default: {
-        // Do nothing
-      }
+    if (wordBankItem.type === ItemTypes.BOTTOM_WORD) {
+      this.props.actions.moveWordBankItemToAlignment(index, wordBankItem);
+    }
+    if (wordBankItem.type === ItemTypes.TOP_WORD) {
+      this.props.actions.mergeAlignments(wordBankItem.alignmentIndex, index);
     }
   }
 }

--- a/src/components/DropBoxItem/BottomWordCard.js
+++ b/src/components/DropBoxItem/BottomWordCard.js
@@ -14,18 +14,20 @@ const internalStyle = {
   cursor: 'move'
 };
 
-class BottomWordCard extends Component {
-  render() {
-    const { word, style, isDragging, connectDragSource } = this.props;
-    const opacity = isDragging ? 0.4 : 1;
+const BottomWordCard = ({
+  word,
+  style,
+  isDragging,
+  connectDragSource
+}) => {
+  const opacity = isDragging ? 0.4 : 1;
 
-    return connectDragSource(
-      <span style={{ ...internalStyle, ...style, opacity }}>
-        {word}
-      </span>
-    );
-  }
-}
+  return connectDragSource(
+    <span style={{ ...internalStyle, ...style, opacity }}>
+      {word}
+    </span>
+  );
+};
 
 BottomWordCard.propTypes = {
   word: PropTypes.string.isRequired,
@@ -44,7 +46,8 @@ const DragBottomWordCardAction = {
       word: props.word,
       occurrence: props.occurrence,
       occurrences: props.occurrences,
-      alignmentIndex: props.alignmentIndex
+      alignmentIndex: props.alignmentIndex,
+      type: ItemTypes.BOTTOM_WORD
     };
     return item;
   }

--- a/src/components/DropBoxItem/BottomWordCard.js
+++ b/src/components/DropBoxItem/BottomWordCard.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import ItemTypes from '../ItemTypes';

--- a/src/components/DropBoxItem/TopWordCard.js
+++ b/src/components/DropBoxItem/TopWordCard.js
@@ -4,14 +4,17 @@ import { DragSource } from 'react-dnd';
 import ItemTypes from '../ItemTypes';
 
 const internalStyle = {
+  display: 'flex',
+  width: '100%',
   borderLeft: '5px solid #44C6FF',
   padding: '10px',
-  marginBottom: '5px',
-  color: '#ffffff',
   textAlign: 'center',
   backgroundColor: '#333333',
   boxShadow: "0 1px 4px rgba(0, 0, 0, 0.3), 0 0 40px rgba(0, 0, 0, 0.1) inset",
-  cursor: 'move'
+  cursor: 'move',
+  color: '#ffffff',
+  marginBottom: '5px',
+  height: '40px'
 };
 
 const TopWordCard = ({

--- a/src/components/DropBoxItem/TopWordCard.js
+++ b/src/components/DropBoxItem/TopWordCard.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { DragSource } from 'react-dnd';
+import ItemTypes from '../ItemTypes';
 
 const internalStyle = {
   borderLeft: '5px solid #44C6FF',
@@ -13,23 +15,54 @@ const internalStyle = {
 };
 
 const TopWordCard = ({
-  words,
-  style
+  word,
+  style,
+  isDragging,
+  connectDragSource
 }) => {
-  return (
-    <span style={{ ...internalStyle, ...style }}>
-      {
-        words.map((wordObject, index) => (
-          <span key={index}>{wordObject.word}&nbsp;</span>
-        ))
-      }
+  const opacity = isDragging ? 0.4 : 1;
+
+  return connectDragSource(
+    <span style={{ ...internalStyle, ...style, opacity }}>
+      {word}
     </span>
   );
 };
 
 TopWordCard.propTypes = {
-  words: PropTypes.array.isRequired,
+  word: PropTypes.string.isRequired,
+  occurrence: PropTypes.number.isRequired,
+  occurrences: PropTypes.number.isRequired,
+  alignmentIndex: PropTypes.number,
+  connectDragSource: PropTypes.func.isRequired,
+  isDragging: PropTypes.bool.isRequired,
   style: PropTypes.object
 };
 
-export default TopWordCard;
+const DragTopWordCardAction = {
+  beginDrag(props) {
+    // Return the data describing the dragged item
+    const item = {
+      word: props.word,
+      occurrence: props.occurrence,
+      occurrences: props.occurrences,
+      alignmentIndex: props.alignmentIndex,
+      type: ItemTypes.TOP_WORD
+    };
+    return item;
+  }
+};
+
+const collect = (connect, monitor) => {
+  return {
+    connectDragSource: connect.dragSource(),
+    connectDragPreview: connect.dragPreview(),
+    isDragging: monitor.isDragging()
+  };
+};
+
+export default DragSource(
+  ItemTypes.TOP_WORD,
+  DragTopWordCardAction,
+  collect
+)(TopWordCard);

--- a/src/components/DropBoxItem/TopWordCard.js
+++ b/src/components/DropBoxItem/TopWordCard.js
@@ -59,9 +59,9 @@ TopWordCard.propTypes = {
     lemma: PropTypes.string.isRequired,
     strongs: PropTypes.string.isRequired,
     occurrence: PropTypes.number.isRequired,
-    occurrences: PropTypes.number.isRequired,
-    alignmentIndex: PropTypes.number.isRequired
+    occurrences: PropTypes.number.isRequired
   }),
+  alignmentIndex: PropTypes.number.isRequired,
   connectDragSource: PropTypes.func.isRequired,
   isDragging: PropTypes.bool.isRequired,
   style: PropTypes.object,
@@ -78,9 +78,9 @@ const DragTopWordCardAction = {
   beginDrag(props) {
     // Return the data describing the dragged item
     const item = {
-      word: props.word,
-      occurrence: props.occurrence,
-      occurrences: props.occurrences,
+      word: props.wordObject.word,
+      occurrence: props.wordObject.occurrence,
+      occurrences: props.wordObject.occurrences,
       alignmentIndex: props.alignmentIndex,
       type: ItemTypes.TOP_WORD
     };

--- a/src/components/DropBoxItem/index.js
+++ b/src/components/DropBoxItem/index.js
@@ -19,7 +19,17 @@ class DropBoxItem extends Component {
     return connectDropTarget(
       <div style={{ padding: '5px 10px', backgroundColor: '#DCDCDC', margin: '0px 10px 10px 0px', height: '100px' }}>
         <div style={{ display: 'flex', flexDirection: 'column', width: '230px', height: '70px', backgroundColor: '#DCDCDC' }}>
-          <TopWordCard words={topWords} />
+          {
+            topWords.map((metadata, index) => (
+              <TopWordCard
+                key={index}
+                word={metadata.word}
+                occurrence={metadata.occurrence}
+                occurrences={metadata.occurrences}
+                alignmentIndex={alignmentIndex}
+              />
+            ))
+          }
           <div style={style}>
             {bottomWords.length > 0 &&
               <div style={{ display: 'flex' }}>
@@ -31,7 +41,6 @@ class DropBoxItem extends Component {
                       occurrence={metadata.occurrence}
                       occurrences={metadata.occurrences}
                       alignmentIndex={alignmentIndex}
-                      hide={canDrop}
                     />
                   ))
                 }
@@ -71,7 +80,7 @@ const collect = (connect, monitor) => {
 };
 
 export default DropTarget(
-  ItemTypes.BOTTOM_WORD, // itemType
+  [ItemTypes.BOTTOM_WORD, ItemTypes.TOP_WORD], // itemType
   DropDropBoxItemAction,
   collect
 )(DropBoxItem);

--- a/src/components/DropBoxItem/index.js
+++ b/src/components/DropBoxItem/index.js
@@ -13,7 +13,7 @@ class DropBoxItem extends Component {
     const style = {
       height: '35px',
       padding: bottomWords.length === 0 ? '15px 0px' : canDrop ? '15px 0px' :'0px',
-      border: isOver ? '3px dashed #44C6FF' : bottomWords.length === 0 ? '3px dashed #ffffff' : canDrop ? '3px dashed #ffffff' : ''
+      border: isOver && canDrop ? '3px dashed #44C6FF' : bottomWords.length === 0 ? '3px dashed #ffffff' : canDrop ? '3px dashed #ffffff' : ''
     };
 
     return connectDropTarget(
@@ -66,6 +66,17 @@ DropBoxItem.propTypes = {
 };
 
 const DropDropBoxItemAction = {
+  canDrop(props, monitor) {
+    const item = monitor.getItem();
+    if (item.type === ItemTypes.TOP_WORD) {
+      const alignmentIndexDelta = props.alignmentIndex - item.alignmentIndex;
+      const canDrop = (Math.abs(alignmentIndexDelta) === 1);
+      return canDrop;
+    }
+    if (item.type === ItemTypes.BOTTOM_WORD) {
+      return true;
+    }
+  },
   drop(props, monitor) {
     props.onDrop(monitor.getItem());
   }

--- a/src/components/DropBoxItem/index.js
+++ b/src/components/DropBoxItem/index.js
@@ -29,6 +29,7 @@ class DropBoxItem extends Component {
                   <TopWordCard
                     key={index}
                     wordObject={wordObject}
+                    alignmentIndex={this.props.alignmentIndex}
                     resourcesReducer={this.props.resourcesReducer}
                     actions={this.props.actions}
                   />

--- a/src/components/DropBoxItem/index.js
+++ b/src/components/DropBoxItem/index.js
@@ -10,7 +10,10 @@ import TopWordCard from './TopWordCard';
 class DropBoxItem extends Component {
   render() {
     const { alignmentIndex, canDrop, isOver, bottomWords, connectDropTarget, topWords } = this.props;
-    const style = {
+    const topStyle = {
+      padding: topWords.length === 0 ? '15px 0px' : '1px 0'
+    };
+    const bottomStyle = {
       height: '35px',
       padding: bottomWords.length === 0 ? '15px 0px' : canDrop ? '15px 0px' :'0px',
       border: isOver && canDrop ? '3px dashed #44C6FF' : bottomWords.length === 0 ? '3px dashed #ffffff' : canDrop ? '3px dashed #ffffff' : ''
@@ -19,18 +22,22 @@ class DropBoxItem extends Component {
     return connectDropTarget(
       <div style={{ padding: '5px 10px', backgroundColor: '#DCDCDC', margin: '0px 10px 10px 0px', height: '100px' }}>
         <div style={{ display: 'flex', flexDirection: 'column', width: '230px', height: '70px', backgroundColor: '#DCDCDC' }}>
-          {
-            topWords.map((metadata, index) => (
-              <TopWordCard
-                key={index}
-                word={metadata.word}
-                occurrence={metadata.occurrence}
-                occurrences={metadata.occurrences}
-                alignmentIndex={alignmentIndex}
-              />
-            ))
-          }
-          <div style={style}>
+          <div style={topStyle}>
+            <div style={{ display: 'flex' }}>
+              {
+                topWords.map((metadata, index) => (
+                  <TopWordCard
+                    key={index}
+                    word={metadata.word}
+                    occurrence={metadata.occurrence}
+                    occurrences={metadata.occurrences}
+                    alignmentIndex={alignmentIndex}
+                  />
+                ))
+              }
+            </div>
+          </div>
+          <div style={bottomStyle}>
             {bottomWords.length > 0 &&
               <div style={{ display: 'flex' }}>
                 {

--- a/src/components/ItemTypes.js
+++ b/src/components/ItemTypes.js
@@ -1,3 +1,4 @@
 export default {
-  BOTTOM_WORD: 'bottomWord'
+  BOTTOM_WORD: 'bottomWord',
+  TOP_WORD: 'topWord'
 };

--- a/src/components/WordBankItem/index.js
+++ b/src/components/WordBankItem/index.js
@@ -18,7 +18,8 @@ const DragWordBankItemAction = {
     const item = {
       word: props.word,
       occurrence: props.occurrence,
-      occurrences: props.occurrences
+      occurrences: props.occurrences,
+      type: ItemTypes.BOTTOM_WORD
     };
     return item;
   },


### PR DESCRIPTION
#### This pull request addresses:

Merging TopWords and aligned bottom words

#### How to test this pull request:

- Checkout the same branch in the translationCore repo.
- Test the dragging and dropping of Top words.
  - Should be droppable one to the left and to the right of it.
  - Should not be droppable on any others.
- Test pre-existing drag and drop functionality of word bank and bottom words.
- Test the dragging and dropping of Top Words that include bottom words.
  - Should merge all bottom words.

#### Known limitations:
- Dragging TopWords that are already merged will merge all pre-merged alignments.
  - This will be addressed after unmerging Top Words as that is a prerequisite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-alignment-tool/6)
<!-- Reviewable:end -->
