### PR TITLE
Updated `UGNT` reference to `BHP`

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -9,8 +9,8 @@ import DropBoxArea from './components/DropBoxArea';
 class Container extends Component {
 
   componentWillMount() {
-    // set the ScripturePane to display ulb and ugnt
-    this.props.actions.setToolSettings("ScripturePane", "currentPaneSettings", ["ulb", "ugnt"]);
+    // set the ScripturePane to display ulb and bhp
+    this.props.actions.setToolSettings("ScripturePane", "currentPaneSettings", ["ulb", "bhp"]);
   }
 
   render() {


### PR DESCRIPTION
#### This pull request addresses:
- Updated `UGNT` reference to `BHP`
 
#### How to test this pull request:
- Delete the resources folder from the `translationCore` folder in the user directory.
- Then open a tool and you should not be able to load UGNT in the scripture pane
- This PR should be tested together with:
https://github.com/unfoldingWord-dev/translationCore/pull/2856
https://github.com/translationCoreApps/tC_Resources/pull/7
https://github.com/translationCoreApps/word-alignment-tool/pull/7
https://github.com/translationCoreApps/ScripturePane/pull/66
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-alignment-tool/7)
<!-- Reviewable:end -->
