### PR TITLE
Unmerging TopWords in Alignment

### DIFF
--- a/src/components/DropBoxArea/index.js
+++ b/src/components/DropBoxArea/index.js
@@ -42,12 +42,12 @@ class DropBoxArea extends Component {
     );
   }
 
-  handleDrop(index, wordBankItem) {
-    if (wordBankItem.type === ItemTypes.BOTTOM_WORD) {
-      this.props.actions.moveWordBankItemToAlignment(index, wordBankItem);
+  handleDrop(index, item) {
+    if (item.type === ItemTypes.BOTTOM_WORD) {
+      this.props.actions.moveWordBankItemToAlignment(index, item);
     }
-    if (wordBankItem.type === ItemTypes.TOP_WORD) {
-      this.props.actions.mergeAlignments(wordBankItem.alignmentIndex, index);
+    if (item.type === ItemTypes.TOP_WORD) {
+      this.props.actions.moveTopWordItemToAlignment(item, item.alignmentIndex, index);
     }
   }
 }

--- a/src/components/DropBoxItem/TopWordCard.js
+++ b/src/components/DropBoxItem/TopWordCard.js
@@ -57,6 +57,7 @@ TopWordCard.propTypes = {
   wordObject: PropTypes.shape({
     word: PropTypes.string.isRequired,
     lemma: PropTypes.string.isRequired,
+    morph: PropTypes.string.isRequired,
     strongs: PropTypes.string.isRequired,
     occurrence: PropTypes.number.isRequired,
     occurrences: PropTypes.number.isRequired
@@ -79,6 +80,9 @@ const DragTopWordCardAction = {
     // Return the data describing the dragged item
     const item = {
       word: props.wordObject.word,
+      lemma: props.wordObject.lemma,
+      morph: props.wordObject.morph,
+      strongs: props.wordObject.strongs,
       occurrence: props.wordObject.occurrence,
       occurrences: props.wordObject.occurrences,
       alignmentIndex: props.alignmentIndex,

--- a/src/components/DropBoxItem/index.js
+++ b/src/components/DropBoxItem/index.js
@@ -82,13 +82,20 @@ DropBoxItem.propTypes = {
 const DropDropBoxItemAction = {
   canDrop(props, monitor) {
     const item = monitor.getItem();
-    if (item.type === ItemTypes.TOP_WORD) {
+    let canDrop;
+    if (item.type === ItemTypes.BOTTOM_WORD) {
       const alignmentIndexDelta = props.alignmentIndex - item.alignmentIndex;
-      const canDrop = (Math.abs(alignmentIndexDelta) === 1);
+      canDrop = alignmentIndexDelta !== 0;
       return canDrop;
     }
-    if (item.type === ItemTypes.BOTTOM_WORD) {
-      return true;
+    if (item.type === ItemTypes.TOP_WORD) {
+      if (props.topWords.length === 0 && props.bottomWords.length === 0) {
+        canDrop = true;
+      } else {
+        const alignmentIndexDelta = props.alignmentIndex - item.alignmentIndex;
+        canDrop = (Math.abs(alignmentIndexDelta) === 1);
+      }
+      return canDrop;
     }
   },
   drop(props, monitor) {


### PR DESCRIPTION
#### This pull request addresses:

Unmerging TopWords in Alignment

#### How to test this pull request:

- Drag and drop TopWords in alignment and see if they behave as expected, including sorting.
- Drag and drop BottomWords and ensure they work as before/expected.
  - Should Sort properly now.
- Drag TopWords together after BottomWords are aligned.
  - Should merge BottomWords from both if the Dragged TopWord was solo.
  - Should reset BottomWords from both if Dragged TopWord was not solo.
- Drag a Merged TopWord to the blank Alignment at the bottom.
  - Should unmerge it and reset BottomWords from where it came.
  - Should properly sort the TopWords.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-alignment-tool/8)
<!-- Reviewable:end -->
