### PR TITLE
Don't show empty alignment if sibling doesn't have enough to take away

### DIFF
--- a/src/components/DropBoxArea/index.js
+++ b/src/components/DropBoxArea/index.js
@@ -39,6 +39,7 @@ class DropBoxArea extends Component {
                   alignmentIndex={index}
                   bottomWords={[]}
                   topWords={[]}
+                  siblingTopWords={alignment.topWords}
                   onDrop={item => this.handleDrop(index, item)}
                   actions={actions}
                   resourcesReducer={resourcesReducer}

--- a/src/components/DropBoxItem/index.js
+++ b/src/components/DropBoxItem/index.js
@@ -87,6 +87,7 @@ DropBoxItem.propTypes = {
   connectDropTarget: PropTypes.func.isRequired,
   topWords: PropTypes.array.isRequired,
   bottomWords: PropTypes.array.isRequired,
+  siblingTopWords: PropTypes.array,
   alignmentIndex: PropTypes.number.isRequired,
   lastDroppedItem: PropTypes.object,
   onDrop: PropTypes.func.isRequired,
@@ -111,7 +112,8 @@ const DropDropBoxItemAction = {
     }
     if (item.type === ItemTypes.TOP_WORD) {
       const alignmentIndexDelta = props.alignmentIndex - item.alignmentIndex;
-      if (alignmentIndexDelta === 0 && alignmentEmpty) {
+      const enoughSiblingTopWords = props.siblingTopWords && props.siblingTopWords.length > 1;
+      if (alignmentIndexDelta === 0 && alignmentEmpty && enoughSiblingTopWords) {
         canDrop = true;
       } else {
         canDrop = (!alignmentEmpty && Math.abs(alignmentIndexDelta) === 1);

--- a/src/components/WordBankArea/index.js
+++ b/src/components/WordBankArea/index.js
@@ -44,7 +44,7 @@ WordBankArea.propTypes = {
   contextIdReducer: PropTypes.object.isRequired,
   wordAlignmentReducer: PropTypes.object.isRequired,
   connectDropTarget: PropTypes.func.isRequired,
-  isOver: PropTypes.func.isRequired
+  isOver: PropTypes.bool.isRequired
 };
 
 const wordBankAreaItemAction = {


### PR DESCRIPTION
#### This pull request addresses:

Don't show empty alignment if sibling doesn't have enough to take away

#### How to test this pull request:

Must test independently of the other matching PR.
This was addressed fundamentally in the core actions and also in the tool UI.
Tool fix addresses root behavior, tool fix prevents it from happening

- Drag a TopWord that is solo an no empty alignment should show up anymore
- Test existing functionality to ensure other use cases weren't broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-alignment-tool/10)
<!-- Reviewable:end -->
