### PR TITLE
Feature/issue 2867 alignment tool automatically scroll target area to the top when moving to new verse

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -15,7 +15,6 @@ class Container extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    console.log(this.props.contextIdReducer);
     if( isEqual(
         this.props.contextIdReducer.contextId, 
         nextProps.contextIdReducer.contextId)) {

--- a/src/Container.js
+++ b/src/Container.js
@@ -5,12 +5,23 @@ import HTML5Backend from 'react-dnd-html5-backend';
 // components
 import WordBankArea from './components/WordBankArea';
 import DropBoxArea from './components/DropBoxArea';
+import isEqual from 'lodash/isEqual';
 
 class Container extends Component {
 
   componentWillMount() {
     // set the ScripturePane to display ulb and bhp
     this.props.actions.setToolSettings("ScripturePane", "currentPaneSettings", ["ulb", "bhp"]);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    console.log(this.props.contextIdReducer);
+    if( isEqual(
+        this.props.contextIdReducer.contextId, 
+        nextProps.contextIdReducer.contextId)) {
+      var page = document.getElementById("DropBoxArea");
+      if (page) page.scrollTop = 0;
+    }
   }
 
   render() {

--- a/src/components/DropBoxArea/index.js
+++ b/src/components/DropBoxArea/index.js
@@ -22,7 +22,7 @@ class DropBoxArea extends Component {
     const { chapter, verse } = contextId.reference;
     const alignments = wordAlignmentReducer.alignmentData[chapter][verse].alignments;
     return (
-      <div style={{ display: 'flex', flexWrap: 'wrap', height: '100%', backgroundColor: '#ffffff', padding: '0px 10px 50px', overflowY: 'auto' }}>
+      <div id='DropBoxArea' style={{ display: 'flex', flexWrap: 'wrap', height: '100%', backgroundColor: '#ffffff', padding: '0px 10px 50px', overflowY: 'auto' }}>
         {
           alignments.map((alignment, index) => {
             return (


### PR DESCRIPTION
Test:
open a titus project
navigate to alignment tool
make window small enough so that there is a vertical scroll bar
Scroll down to middle
change to a different verse

Note that window should scroll to top

Scroll down to middle
now Change to a different chapter

Note that window should scroll to top

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-alignment-tool/12)
<!-- Reviewable:end -->
