### PR TITLE
Bugfix #3486/wA Tool crashes on missing alignment data for verse.

### DIFF
--- a/__tests__/DropBoxArea.test.js
+++ b/__tests__/DropBoxArea.test.js
@@ -1,13 +1,75 @@
 import React from 'react';
 import DropBoxArea from '../src/components/DropBoxArea';
-import renderer from 'react-test-renderer';
+import {shallow} from 'enzyme';
 
-test('DropBoxArea renders', () => {
-    const component = renderer.create(
-        <DropBoxArea />
+describe('DropBoxArea', () => {
+  let contextIdReducer ,wordAlignmentReducer, resourcesReducer;
+  const luke1 = require('./fixtures/luke/1.json');
+
+  beforeEach(() => {
+    contextIdReducer = {
+      "contextId": {
+        "groupId": "figs_metaphor",
+        "occurrence": 1,
+        "quote": "that he put before them",
+        "information": "Paul speaks about good deeds as if they were objects that God could place in front of people. AT: \"that God prepared for them to do\" (See: [[:en:ta:vol1:translate:figs_metaphor]]) \n",
+        "reference": {
+          "bookId": "luk",
+          "chapter": 1,
+          "verse": 1
+        },
+        "tool": "TranslationNotesChecker"
+      }
+    };
+    wordAlignmentReducer = {
+      alignmentData: {
+        "1": luke1
+      }
+    };
+    resourcesReducer = {
+      lexicons: {}
+    };
+  });
+
+  test('DropBoxArea renders Luke 1:1', () => {
+    const chapter = "1";
+    const verse = "1";
+    contextIdReducer.contextId.reference.chapter = chapter;
+    contextIdReducer.contextId.reference.verse = verse;
+    const expectedWords = wordAlignmentReducer.alignmentData[chapter][verse].alignments.length;
+    const enzymeWrapper = shallow(
+      <DropBoxArea
+        wordAlignmentReducer={wordAlignmentReducer}
+        contextIdReducer={contextIdReducer}
+        actions={{}}
+        resourcesReducer={resourcesReducer}
+      />
     );
-    let tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
 
-    // TODO: exercise UI
+    const dropBoxArea = enzymeWrapper.find('div');
+    expect(dropBoxArea).toBeTruthy();
+    expect(dropBoxArea.nodes.length).toEqual(expectedWords + 1);
+  });
+
+  test('DropBoxArea renders undefined Luke 1:81 without crashing', () => {
+    const chapter = "1";
+    const verse = "81";
+    contextIdReducer.contextId.reference.chapter = chapter;
+    contextIdReducer.contextId.reference.verse = verse;
+    const expectedWords = 0;
+    const enzymeWrapper = shallow(
+      <DropBoxArea
+        wordAlignmentReducer={wordAlignmentReducer}
+        contextIdReducer={contextIdReducer}
+        actions={{}}
+        resourcesReducer={resourcesReducer}
+      />
+    );
+
+    const dropBoxArea = enzymeWrapper.find('div');
+    expect(dropBoxArea).toBeTruthy();
+    expect(dropBoxArea.nodes.length).toEqual(expectedWords + 1);
+  });
+
+  // TODO: exercise UI
 });

--- a/__tests__/DropBoxArea.test.js
+++ b/__tests__/DropBoxArea.test.js
@@ -4,13 +4,13 @@ import {shallow} from 'enzyme';
 import renderer from 'react-test-renderer';
 
 test('DropBoxArea renders', () => {
-  const component = renderer.create(
-    <DropBoxArea />
-  );
-  let tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+    const component = renderer.create(
+        <DropBoxArea />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
 
-  // TODO: exercise UI
+    // TODO: exercise UI
 });
 
 describe('DropBoxArea', () => {

--- a/__tests__/DropBoxArea.test.js
+++ b/__tests__/DropBoxArea.test.js
@@ -3,6 +3,16 @@ import DropBoxArea from '../src/components/DropBoxArea';
 import {shallow} from 'enzyme';
 import renderer from 'react-test-renderer';
 
+test('DropBoxArea renders', () => {
+  const component = renderer.create(
+    <DropBoxArea />
+  );
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+
+  // TODO: exercise UI
+});
+
 describe('DropBoxArea', () => {
   let contextIdReducer ,wordAlignmentReducer, resourcesReducer;
   const luke1 = require('./fixtures/luke/1.json');
@@ -71,14 +81,4 @@ describe('DropBoxArea', () => {
     expect(dropBoxArea).toBeTruthy();
     expect(dropBoxArea.nodes.length).toEqual(expectedWords + 1);
   });
-});
-
-test('DropBoxArea renders', () => {
-  const component = renderer.create(
-    <DropBoxArea />
-  );
-  let tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-
-  // TODO: exercise UI
 });

--- a/__tests__/DropBoxArea.test.js
+++ b/__tests__/DropBoxArea.test.js
@@ -43,11 +43,14 @@ describe('DropBoxArea', () => {
   });
 
   test('DropBoxArea renders Luke 1:1', () => {
+    // given
     const chapter = "1";
     const verse = "1";
     contextIdReducer.contextId.reference.chapter = chapter;
     contextIdReducer.contextId.reference.verse = verse;
     const expectedWords = wordAlignmentReducer.alignmentData[chapter][verse].alignments.length;
+
+    // when
     const enzymeWrapper = shallow(
       <DropBoxArea
         wordAlignmentReducer={wordAlignmentReducer}
@@ -57,17 +60,21 @@ describe('DropBoxArea', () => {
       />
     );
 
+    // then
     const dropBoxArea = enzymeWrapper.find('div');
     expect(dropBoxArea).toBeTruthy();
     expect(dropBoxArea.nodes.length).toEqual(expectedWords + 1);
   });
 
   test('DropBoxArea renders undefined Luke 1:81 without crashing', () => {
+    // given
     const chapter = "1";
     const verse = "81";
     contextIdReducer.contextId.reference.chapter = chapter;
     contextIdReducer.contextId.reference.verse = verse;
     const expectedWords = 0;
+
+    // when
     const enzymeWrapper = shallow(
       <DropBoxArea
         wordAlignmentReducer={wordAlignmentReducer}
@@ -77,6 +84,7 @@ describe('DropBoxArea', () => {
       />
     );
 
+    // then
     const dropBoxArea = enzymeWrapper.find('div');
     expect(dropBoxArea).toBeTruthy();
     expect(dropBoxArea.nodes.length).toEqual(expectedWords + 1);

--- a/__tests__/DropBoxArea.test.js
+++ b/__tests__/DropBoxArea.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import DropBoxArea from '../src/components/DropBoxArea';
 import {shallow} from 'enzyme';
+import renderer from 'react-test-renderer';
 
 describe('DropBoxArea', () => {
   let contextIdReducer ,wordAlignmentReducer, resourcesReducer;
@@ -70,6 +71,14 @@ describe('DropBoxArea', () => {
     expect(dropBoxArea).toBeTruthy();
     expect(dropBoxArea.nodes.length).toEqual(expectedWords + 1);
   });
+});
+
+test('DropBoxArea renders', () => {
+  const component = renderer.create(
+    <DropBoxArea />
+  );
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
 
   // TODO: exercise UI
 });

--- a/__tests__/WordBankArea.test.js
+++ b/__tests__/WordBankArea.test.js
@@ -9,13 +9,13 @@ import WordBankArea from '../src/components/WordBankArea';
 import WordBankItem from '../src/components/WordBankItem';
 
 test('WordBankItem renders', () => {
-  const component = renderer.create(
-    <WordBankArea />
-  );
-  let tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+    const component = renderer.create(
+        <WordBankArea />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
 
-  // TODO: exercise UI
+    // TODO: exercise UI
 });
 
 describe('WordBankArea', () => {

--- a/__tests__/WordBankArea.test.js
+++ b/__tests__/WordBankArea.test.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 import TestBackend from 'react-dnd-test-backend';
 import { DragDropContext } from 'react-dnd';
 import TestUtils from 'react-dom/test-utils';
+import renderer from 'react-test-renderer';
 import WordBankArea from '../src/components/WordBankArea';
 import WordBankItem from '../src/components/WordBankItem';
 
@@ -77,6 +78,15 @@ describe('WordBankArea', () => {
     expect(wordBankItems).toBeTruthy();
     expect(wordBankItems.length).toEqual(expectedWords);
   });
+});
+
+
+test('WordBankItem renders', () => {
+  const component = renderer.create(
+    <WordBankArea />
+  );
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
 
   // TODO: exercise UI
 });

--- a/__tests__/WordBankArea.test.js
+++ b/__tests__/WordBankArea.test.js
@@ -1,13 +1,99 @@
-import React from 'react';
+/* eslint-env jest */
+
+import React, { Component } from 'react';
+import TestBackend from 'react-dnd-test-backend';
+import { DragDropContext } from 'react-dnd';
+import TestUtils from 'react-dom/test-utils';
 import WordBankArea from '../src/components/WordBankArea';
-import renderer from 'react-test-renderer';
+import WordBankItem from '../src/components/WordBankItem';
 
-test('WordBankItem renders', () => {
-    const component = renderer.create(
-        <WordBankArea />
+describe('WordBankArea', () => {
+  let contextIdReducer ,wordAlignmentReducer, connectDropTarget;
+  const luke1 = require('./fixtures/luke/1.json');
+
+  beforeEach(() => {
+    contextIdReducer = {
+      "contextId": {
+        "groupId": "figs_metaphor",
+        "occurrence": 1,
+        "quote": "that he put before them",
+        "information": "Paul speaks about good deeds as if they were objects that God could place in front of people. AT: \"that God prepared for them to do\" (See: [[:en:ta:vol1:translate:figs_metaphor]]) \n",
+        "reference": {
+          "bookId": "luk",
+          "chapter": 1,
+          "verse": 1
+        },
+        "tool": "TranslationNotesChecker"
+      }
+    };
+    wordAlignmentReducer = {
+      alignmentData: {
+        "1": luke1
+      }
+    };
+    connectDropTarget = div => {
+      return div;
+    };
+  });
+
+  test('WordBankArea renders Luke 1:1', () => {
+    const chapter = "1";
+    const verse = "1";
+    contextIdReducer.contextId.reference.chapter = chapter;
+    contextIdReducer.contextId.reference.verse = verse;
+    const expectedWords = wordAlignmentReducer.alignmentData[chapter][verse].wordBank.length;
+    const WordBankAreaContext = wrapInTestContext(WordBankArea);
+    let root = TestUtils.renderIntoDocument(
+      <WordBankAreaContext
+        wordAlignmentReducer={wordAlignmentReducer}
+        contextIdReducer={contextIdReducer}
+        connectDropTarget={connectDropTarget}
+        isOver={false}
+      />
     );
-    let tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
 
-    // TODO: exercise UI
+    let wordBankItems = TestUtils.scryRenderedComponentsWithType(root, WordBankItem);
+    expect(wordBankItems).toBeTruthy();
+    expect(wordBankItems.length).toEqual(expectedWords);
+  });
+
+  test('WordBankArea renders undefined Luke 1:81 without crashing', () => {
+    const chapter = "1";
+    const verse = "81";
+    contextIdReducer.contextId.reference.chapter = chapter;
+    contextIdReducer.contextId.reference.verse = verse;
+    const expectedWords = 0;
+    const WordBankAreaContext = wrapInTestContext(WordBankArea);
+    let root = TestUtils.renderIntoDocument(
+      <WordBankAreaContext
+        wordAlignmentReducer={wordAlignmentReducer}
+        contextIdReducer={contextIdReducer}
+        connectDropTarget={connectDropTarget}
+        isOver={false}
+      />
+    );
+
+    let wordBankItems = TestUtils.scryRenderedComponentsWithType(root, WordBankItem);
+    expect(wordBankItems).toBeTruthy();
+    expect(wordBankItems.length).toEqual(expectedWords);
+  });
+
+  // TODO: exercise UI
 });
+
+//
+// Helpers
+//
+
+/**
+ * Wraps a component into a DragDropContext that uses the TestBackend.
+ */
+function wrapInTestContext(DecoratedComponent) {
+  return DragDropContext(TestBackend)(
+    class TestContextContainer extends Component {
+      render() {
+        return <DecoratedComponent {...this.props} />;
+      }
+    }
+  );
+}

--- a/__tests__/WordBankArea.test.js
+++ b/__tests__/WordBankArea.test.js
@@ -48,12 +48,15 @@ describe('WordBankArea', () => {
   });
 
   test('WordBankArea renders Luke 1:1', () => {
+    // given
     const chapter = "1";
     const verse = "1";
     contextIdReducer.contextId.reference.chapter = chapter;
     contextIdReducer.contextId.reference.verse = verse;
     const expectedWords = wordAlignmentReducer.alignmentData[chapter][verse].wordBank.length;
     const WordBankAreaContext = wrapInTestContext(WordBankArea);
+
+    // when
     let root = TestUtils.renderIntoDocument(
       <WordBankAreaContext
         wordAlignmentReducer={wordAlignmentReducer}
@@ -63,18 +66,22 @@ describe('WordBankArea', () => {
       />
     );
 
+    // then
     let wordBankItems = TestUtils.scryRenderedComponentsWithType(root, WordBankItem);
     expect(wordBankItems).toBeTruthy();
     expect(wordBankItems.length).toEqual(expectedWords);
   });
 
   test('WordBankArea renders undefined Luke 1:81 without crashing', () => {
+    // given
     const chapter = "1";
     const verse = "81";
     contextIdReducer.contextId.reference.chapter = chapter;
     contextIdReducer.contextId.reference.verse = verse;
     const expectedWords = 0;
     const WordBankAreaContext = wrapInTestContext(WordBankArea);
+
+    // when
     let root = TestUtils.renderIntoDocument(
       <WordBankAreaContext
         wordAlignmentReducer={wordAlignmentReducer}
@@ -84,6 +91,7 @@ describe('WordBankArea', () => {
       />
     );
 
+    // then
     let wordBankItems = TestUtils.scryRenderedComponentsWithType(root, WordBankItem);
     expect(wordBankItems).toBeTruthy();
     expect(wordBankItems.length).toEqual(expectedWords);

--- a/__tests__/WordBankArea.test.js
+++ b/__tests__/WordBankArea.test.js
@@ -8,6 +8,16 @@ import renderer from 'react-test-renderer';
 import WordBankArea from '../src/components/WordBankArea';
 import WordBankItem from '../src/components/WordBankItem';
 
+test('WordBankItem renders', () => {
+  const component = renderer.create(
+    <WordBankArea />
+  );
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+
+  // TODO: exercise UI
+});
+
 describe('WordBankArea', () => {
   let contextIdReducer ,wordAlignmentReducer, connectDropTarget;
   const luke1 = require('./fixtures/luke/1.json');
@@ -78,17 +88,6 @@ describe('WordBankArea', () => {
     expect(wordBankItems).toBeTruthy();
     expect(wordBankItems.length).toEqual(expectedWords);
   });
-});
-
-
-test('WordBankItem renders', () => {
-  const component = renderer.create(
-    <WordBankArea />
-  );
-  let tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-
-  // TODO: exercise UI
 });
 
 //

--- a/__tests__/fixtures/luke/1.json
+++ b/__tests__/fixtures/luke/1.json
@@ -1,0 +1,23076 @@
+{
+  "1": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἐπειδήπερ",
+            "strongs": "G18950",
+            "lemma": "ἐπειδήπερ",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πολλοὶ",
+            "strongs": "G41830",
+            "lemma": "πολλός",
+            "morph": "Gr,RI,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπεχείρησαν",
+            "strongs": "G20210",
+            "lemma": "ἐπιχειρέω",
+            "morph": "Gr,V,IAA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀνατάξασθαι",
+            "strongs": "G03920",
+            "lemma": "ἀνατάσσομαι",
+            "morph": "Gr,V,NAM,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διήγησιν",
+            "strongs": "G13350",
+            "lemma": "διήγησις",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "περὶ",
+            "strongs": "G40120",
+            "lemma": "περί",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῶν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πεπληροφορημένων",
+            "strongs": "G41350",
+            "lemma": "πληροφορέω",
+            "morph": "Gr,V,PEP,GNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῖν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1D,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πραγμάτων",
+            "strongs": "G42290",
+            "lemma": "πρᾶγμα",
+            "morph": "Gr,N,,,,,GNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Many",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "have",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "taken",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "on",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "work",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "putting",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "together",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "an",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "account",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "things",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "have",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "been",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "fulfilled",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "among",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "us",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "2": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καθὼς",
+            "strongs": "G25310",
+            "lemma": "καθώς",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παρέδοσαν",
+            "strongs": "G38600",
+            "lemma": "παραδίδωμι",
+            "morph": "Gr,V,IAA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῖν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1D,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἱ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπ’",
+            "strongs": "G05750",
+            "lemma": "ἀπό",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀρχῆς",
+            "strongs": "G07460",
+            "lemma": "ἀρχή",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτόπται",
+            "strongs": "G08450",
+            "lemma": "αὐτόπτης",
+            "morph": "Gr,N,,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὑπηρέται",
+            "strongs": "G52570",
+            "lemma": "ὑπηρέτης",
+            "morph": "Gr,N,,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γενόμενοι",
+            "strongs": "G10960",
+            "lemma": "γίνομαι",
+            "morph": "Gr,V,PAM,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λόγου",
+            "strongs": "G30560",
+            "lemma": "λόγος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "just",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "as",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "they",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "were",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "passed",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "down",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "us",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "by",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "those",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "from",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "first",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "were",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "eyewitnesses",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "servants",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "3": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἔδοξε",
+            "strongs": "G13800",
+            "lemma": "δοκέω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κἀμοὶ",
+            "strongs": "G25040",
+            "lemma": "κἀγώ",
+            "morph": "Gr,RP,,,1D,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παρηκολουθηκότι",
+            "strongs": "G38770",
+            "lemma": "παρακολουθέω",
+            "morph": "Gr,V,PEA,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄνωθεν",
+            "strongs": "G05090",
+            "lemma": "ἄνωθεν",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πᾶσιν",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,RI,,,,DNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀκριβῶς",
+            "strongs": "G01990",
+            "lemma": "ἀκριβῶς",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καθεξῆς",
+            "strongs": "G25170",
+            "lemma": "καθεξῆς",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σοι",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2D,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γράψαι",
+            "strongs": "G11250",
+            "lemma": "γράφω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κράτιστε",
+            "strongs": "G29030",
+            "lemma": "κράτιστος",
+            "morph": "Gr,AA,,,,VMSS",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεόφιλε",
+            "strongs": "G23210",
+            "lemma": "Θεόφιλος",
+            "morph": "Gr,N,,,,,VMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "So",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "it",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "seemed",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "good",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "me",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "also",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "because",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "I",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "have",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "accurately",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "investigated",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "everything",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "from",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "beginning",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "write",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "an",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "orderly",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "account",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "most",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "excellent",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Theophilus",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "4": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἵνα",
+            "strongs": "G24430",
+            "lemma": "ἵνα",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπιγνῷς",
+            "strongs": "G19210",
+            "lemma": "ἐπιγινώσκω",
+            "morph": "Gr,V,SAA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "περὶ",
+            "strongs": "G40120",
+            "lemma": "περί",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὧν",
+            "strongs": "G37390",
+            "lemma": "ὅς",
+            "morph": "Gr,RR,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κατηχήθης",
+            "strongs": "G27270",
+            "lemma": "κατηχέω",
+            "morph": "Gr,V,IAP2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λόγων",
+            "strongs": "G30560",
+            "lemma": "λόγος",
+            "morph": "Gr,N,,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὴν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀσφάλειαν",
+            "strongs": "G08030",
+            "lemma": "ἀσφάλεια",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "so",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "might",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "know",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "certainty",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "things",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "have",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "been",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "taught",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "5": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἐγένετο",
+            "strongs": "G10960",
+            "lemma": "γίνομαι",
+            "morph": "Gr,V,IAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέραις",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἡρῴδου",
+            "strongs": "G22640",
+            "lemma": "Ἡρῴδης",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "βασιλέως",
+            "strongs": "G09350",
+            "lemma": "βασιλεύς",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰουδαίας",
+            "strongs": "G24490",
+            "lemma": "Ἰουδαία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἱερεύς",
+            "strongs": "G24090",
+            "lemma": "ἱερεύς",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τις",
+            "strongs": "G51000",
+            "lemma": "τις",
+            "morph": "Gr,EQ,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὀνόματι",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ζαχαρίας",
+            "strongs": "G21970",
+            "lemma": "Ζαχαρίας",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐξ",
+            "strongs": "G15370",
+            "lemma": "ἐκ",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐφημερίας",
+            "strongs": "G21830",
+            "lemma": "ἐφημερία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἀβιά",
+            "strongs": "G00070",
+            "lemma": "Ἀβιά",
+            "morph": "Gr,N,,,,,GMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γυνὴ",
+            "strongs": "G11350",
+            "lemma": "γυνή",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῷ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐκ",
+            "strongs": "G15370",
+            "lemma": "ἐκ",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῶν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "θυγατέρων",
+            "strongs": "G23640",
+            "lemma": "θυγάτηρ",
+            "morph": "Gr,N,,,,,GFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἀαρών",
+            "strongs": "G00020",
+            "lemma": "Ἀαρών",
+            "morph": "Gr,N,,,,,GMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὄνομα",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῆς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἐλεισάβετ",
+            "strongs": "G16650",
+            "lemma": "Ἐλεισάβετ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "In",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "days",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "Herod",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "king",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 2,
+        "occurrences": 4
+      },
+      {
+        "word": "Judea",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "there",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 16
+      },
+      {
+        "word": "certain",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "priest",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "named",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Zechariah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "from",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 4
+      },
+      {
+        "word": "division",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 3,
+        "occurrences": 4
+      },
+      {
+        "word": "Abijah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "His",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "wife",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "from",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 3,
+        "occurrences": 4
+      },
+      {
+        "word": "daughters",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 4,
+        "occurrences": 4
+      },
+      {
+        "word": "Aaron",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "name",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "was",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "word": "Elizabeth",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "6": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἦσαν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IIA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δίκαιοι",
+            "strongs": "G13420",
+            "lemma": "δίκαιος",
+            "morph": "Gr,NP,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀμφότεροι",
+            "strongs": "G02970",
+            "lemma": "ἀμφοτερός",
+            "morph": "Gr,EQ,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐναντίον",
+            "strongs": "G17260",
+            "lemma": "ἐναντίον",
+            "morph": "Gr,PI,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεοῦ",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πορευόμενοι",
+            "strongs": "G41980",
+            "lemma": "πορεύω",
+            "morph": "Gr,V,PPM,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πάσαις",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,EQ,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐντολαῖς",
+            "strongs": "G17850",
+            "lemma": "ἐντολή",
+            "morph": "Gr,N,,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δικαιώμασιν",
+            "strongs": "G13450",
+            "lemma": "δικαίωμα",
+            "morph": "Gr,N,,,,,DNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κυρίου",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄμεμπτοι",
+            "strongs": "G02730",
+            "lemma": "ἄμεμπτος",
+            "morph": "Gr,NS,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "They",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "were",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "both",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "righteous",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "before",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "obeying",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "all",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "commandments",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "ordinances",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "7": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὐκ",
+            "strongs": "G37560",
+            "lemma": "οὐ",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἦν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῖς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τέκνον",
+            "strongs": "G50430",
+            "lemma": "τέκνον",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καθότι",
+            "strongs": "G25300",
+            "lemma": "καθότι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἦν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἐλεισάβετ",
+            "strongs": "G16650",
+            "lemma": "Ἐλεισάβετ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "στεῖρα",
+            "strongs": "G47230",
+            "lemma": "στεῖρος",
+            "morph": "Gr,NP,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀμφότεροι",
+            "strongs": "G02970",
+            "lemma": "ἀμφοτερός",
+            "morph": "Gr,RI,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "προβεβηκότες",
+            "strongs": "G42600",
+            "lemma": "προβαίνω",
+            "morph": "Gr,V,PEA,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέραις",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῶν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἦσαν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IIA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "But",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "they",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "had",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "no",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "child",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "because",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Elizabeth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "barren",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "they",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "were",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "both",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "very",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "old",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "by",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "this",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "time",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "8": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἐγένετο",
+            "strongs": "G10960",
+            "lemma": "γίνομαι",
+            "morph": "Gr,V,IAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἱερατεύειν",
+            "strongs": "G24070",
+            "lemma": "ἱερατεύω",
+            "morph": "Gr,V,NPA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτὸν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τάξει",
+            "strongs": "G50100",
+            "lemma": "τάξις",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐφημερίας",
+            "strongs": "G21830",
+            "lemma": "ἐφημερία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔναντι",
+            "strongs": "G17250",
+            "lemma": "ἔναντι",
+            "morph": "Gr,PI,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεοῦ",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Now",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "it",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "came",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "about",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Zechariah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "s",
+        "occurrence": 1,
+        "occurrences": 7
+      },
+      {
+        "word": "presence",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "carrying",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "out",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "priestly",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "duties",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "order",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "division",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "9": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "κατὰ",
+            "strongs": "G25960",
+            "lemma": "κατά",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔθος",
+            "strongs": "G14850",
+            "lemma": "ἔθος",
+            "morph": "Gr,N,,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἱερατείας",
+            "strongs": "G24050",
+            "lemma": "ἱερατεία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔλαχε",
+            "strongs": "G29750",
+            "lemma": "λαγχάνω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "θυμιᾶσαι",
+            "strongs": "G23700",
+            "lemma": "θυμιάω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰσελθὼν",
+            "strongs": "G15250",
+            "lemma": "εἰσέρχομαι",
+            "morph": "Gr,V,PAA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ναὸν",
+            "strongs": "G34850",
+            "lemma": "ναός",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κυρίου",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "According",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 5
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "customary",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "way",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "choosing",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "which",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "priest",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "would",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "serve",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "had",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "been",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "chosen",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "by",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "lot",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 5
+      },
+      {
+        "word": "enter",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "into",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "temple",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 3,
+        "occurrences": 5
+      },
+      {
+        "word": "burn",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "incense",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "10": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πᾶν",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,EQ,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πλῆθος",
+            "strongs": "G41280",
+            "lemma": "πλῆθος",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἦν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λαοῦ",
+            "strongs": "G29920",
+            "lemma": "λαός",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "προσευχόμενον",
+            "strongs": "G43360",
+            "lemma": "προσεύχομαι",
+            "morph": "Gr,V,PPM,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔξω",
+            "strongs": "G18540",
+            "lemma": "ἔξω",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὥρᾳ",
+            "strongs": "G56100",
+            "lemma": "ὥρα",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GNS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "θυμιάματος",
+            "strongs": "G23680",
+            "lemma": "θυμίαμα",
+            "morph": "Gr,N,,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "The",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "whole",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "crowd",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "people",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "praying",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "outside",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "at",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "hour",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "when",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "incense",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "burned",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "11": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ὤφθη",
+            "strongs": "G37080",
+            "lemma": "ὁράω",
+            "morph": "Gr,V,IAP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῷ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄγγελος",
+            "strongs": "G00320",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κυρίου",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἑστὼς",
+            "strongs": "G24760",
+            "lemma": "ἵστημι",
+            "morph": "Gr,V,PEA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐκ",
+            "strongs": "G15370",
+            "lemma": "ἐκ",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δεξιῶν",
+            "strongs": "G11880",
+            "lemma": "δεξιός",
+            "morph": "Gr,NS,,,,GNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "θυσιαστηρίου",
+            "strongs": "G23790",
+            "lemma": "θυσιαστήριον",
+            "morph": "Gr,N,,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GNS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "θυμιάματος",
+            "strongs": "G23680",
+            "lemma": "θυμίαμα",
+            "morph": "Gr,N,,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Now",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "an",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "angel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "appeared",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "stood",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "at",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "right",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "side",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "word": "incense",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "altar",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "12": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐταράχθη",
+            "strongs": "G50150",
+            "lemma": "ταράσσω",
+            "morph": "Gr,V,IAP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ζαχαρίας",
+            "strongs": "G21970",
+            "lemma": "Ζαχαρίας",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἰδών",
+            "strongs": "G37080",
+            "lemma": "ὁράω",
+            "morph": "Gr,V,PAA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "φόβος",
+            "strongs": "G54010",
+            "lemma": "φόβος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπέπεσεν",
+            "strongs": "G19680",
+            "lemma": "ἐπιπίπτω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπ’",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτόν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "When",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Zechariah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "saw",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "terrified",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "fear",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "fell",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "on",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "him",
+        "occurrence": 2,
+        "occurrences": 2
+      }
+    ]
+  },
+  "13": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτὸν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄγγελος",
+            "strongs": "G00320",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μὴ",
+            "strongs": "G33610",
+            "lemma": "μή",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "φοβοῦ",
+            "strongs": "G53990",
+            "lemma": "φοβέω",
+            "morph": "Gr,V,MPM2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ζαχαρία",
+            "strongs": "G21970",
+            "lemma": "Ζαχαρίας",
+            "morph": "Gr,N,,,,,VMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διότι",
+            "strongs": "G13600",
+            "lemma": "διότι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰσηκούσθη",
+            "strongs": "G15220",
+            "lemma": "εἰσακούω",
+            "morph": "Gr,V,IAP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δέησίς",
+            "strongs": "G11620",
+            "lemma": "δέησις",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σου",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2G,S,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γυνή",
+            "strongs": "G11350",
+            "lemma": "γυνή",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σου",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2G,S,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἐλεισάβετ",
+            "strongs": "G16650",
+            "lemma": "Ἐλεισάβετ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γεννήσει",
+            "strongs": "G10800",
+            "lemma": "γεννάω",
+            "morph": "Gr,V,IFA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "υἱόν",
+            "strongs": "G52070",
+            "lemma": "υἱός",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σοι",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2D,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καλέσεις",
+            "strongs": "G25640",
+            "lemma": "καλέω",
+            "morph": "Gr,V,IFA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὄνομα",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰωάννην",
+            "strongs": "G24910",
+            "lemma": "Ἰωάννης",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "But",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "angel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Do",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "not",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 5
+      },
+      {
+        "word": "afraid",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Zechariah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "because",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "your",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "prayer",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "been",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "heard",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Your",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "wife",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Elizabeth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "bear",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 15
+      },
+      {
+        "word": "son",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "You",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "will",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "call",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "name",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "John",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "14": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔσται",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IFM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "χαρά",
+            "strongs": "G54790",
+            "lemma": "χαρά",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σοι",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2D,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀγαλλίασις",
+            "strongs": "G00200",
+            "lemma": "ἀγαλλίασις",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 3,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πολλοὶ",
+            "strongs": "G41830",
+            "lemma": "πολλός",
+            "morph": "Gr,RI,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπὶ",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γενέσει",
+            "strongs": "G10780",
+            "lemma": "γένεσις",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "χαρήσονται",
+            "strongs": "G54630",
+            "lemma": "χαίρω",
+            "morph": "Gr,V,IFP3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "You",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "have",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "joy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "gladness",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "many",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "rejoice",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "at",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "birth",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "15": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἔσται",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IFM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γὰρ",
+            "strongs": "G10630",
+            "lemma": "γάρ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μέγας",
+            "strongs": "G31730",
+            "lemma": "μέγας",
+            "morph": "Gr,NP,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐνώπιον",
+            "strongs": "G17990",
+            "lemma": "ἐνώπιον",
+            "morph": "Gr,PI,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κυρίου",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἶνον",
+            "strongs": "G36310",
+            "lemma": "οἶνος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σίκερα",
+            "strongs": "G46080",
+            "lemma": "σίκερα",
+            "morph": "Gr,N,,,,,ANSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὐ",
+            "strongs": "G37560",
+            "lemma": "οὐ",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μὴ",
+            "strongs": "G33610",
+            "lemma": "μή",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πίῃ",
+            "strongs": "G40950",
+            "lemma": "πίνω",
+            "morph": "Gr,V,SAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 3,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Πνεύματος",
+            "strongs": "G41510",
+            "lemma": "πνεῦμα",
+            "morph": "Gr,N,,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἁγίου",
+            "strongs": "G00400",
+            "lemma": "ἅγιος",
+            "morph": "Gr,AA,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πλησθήσεται",
+            "strongs": "G41300",
+            "lemma": "πλήθω",
+            "morph": "Gr,V,IFP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔτι",
+            "strongs": "G20890",
+            "lemma": "ἔτι",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐκ",
+            "strongs": "G15370",
+            "lemma": "ἐκ",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κοιλίας",
+            "strongs": "G28360",
+            "lemma": "κοιλία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μητρὸς",
+            "strongs": "G33840",
+            "lemma": "μήτηρ",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "For",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 6
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "great",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "sight",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 4
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "must",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "never",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "drink",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "wine",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "or",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "strong",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "drink",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 2,
+        "occurrences": 6
+      },
+      {
+        "word": "will",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "be",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "filled",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 3,
+        "occurrences": 4
+      },
+      {
+        "word": "Holy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Spirit",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "from",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "mother",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "s",
+        "occurrence": 1,
+        "occurrences": 5
+      },
+      {
+        "word": "womb",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "16": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πολλοὺς",
+            "strongs": "G41830",
+            "lemma": "πολλός",
+            "morph": "Gr,RI,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῶν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "υἱῶν",
+            "strongs": "G52070",
+            "lemma": "υἱός",
+            "morph": "Gr,N,,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰσραὴλ",
+            "strongs": "G24740",
+            "lemma": "Ἰσραήλ",
+            "morph": "Gr,N,,,,,GMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπιστρέψει",
+            "strongs": "G19940",
+            "lemma": "ἐπιστρέφω",
+            "morph": "Gr,V,IFA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπὶ",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κύριον",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεὸν",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῶν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Many",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "people",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "Israel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "turned",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "their",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "17": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτὸς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "προελεύσεται",
+            "strongs": "G42810",
+            "lemma": "προέρχομαι",
+            "morph": "Gr,V,IFM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐνώπιον",
+            "strongs": "G17990",
+            "lemma": "ἐνώπιον",
+            "morph": "Gr,PI,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πνεύματι",
+            "strongs": "G41510",
+            "lemma": "πνεῦμα",
+            "morph": "Gr,N,,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δυνάμει",
+            "strongs": "G14110",
+            "lemma": "δύναμις",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἠλεία",
+            "strongs": "G22430",
+            "lemma": "Ἠλείας",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπιστρέψαι",
+            "strongs": "G19940",
+            "lemma": "ἐπιστρέφω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καρδίας",
+            "strongs": "G25880",
+            "lemma": "καρδία",
+            "morph": "Gr,N,,,,,AFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πατέρων",
+            "strongs": "G39620",
+            "lemma": "πατήρ",
+            "morph": "Gr,N,,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπὶ",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τέκνα",
+            "strongs": "G50430",
+            "lemma": "τέκνον",
+            "morph": "Gr,N,,,,,ANP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 3,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπειθεῖς",
+            "strongs": "G05450",
+            "lemma": "ἀπειθής",
+            "morph": "Gr,NS,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "φρονήσει",
+            "strongs": "G54280",
+            "lemma": "φρόνησις",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δικαίων",
+            "strongs": "G13420",
+            "lemma": "δίκαιος",
+            "morph": "Gr,NS,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἑτοιμάσαι",
+            "strongs": "G20900",
+            "lemma": "ἑτοιμάζω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κυρίῳ",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λαὸν",
+            "strongs": "G29920",
+            "lemma": "λαός",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κατεσκευασμένον",
+            "strongs": "G26800",
+            "lemma": "κατασκευάζω",
+            "morph": "Gr,V,PEP,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "go",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "before",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 11
+      },
+      {
+        "word": "face",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 11
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 3,
+        "occurrences": 11
+      },
+      {
+        "word": "spirit",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "power",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 2,
+        "occurrences": 4
+      },
+      {
+        "word": "Elijah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "turn",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 4,
+        "occurrences": 11
+      },
+      {
+        "word": "hearts",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 3,
+        "occurrences": 4
+      },
+      {
+        "word": "the",
+        "occurrence": 5,
+        "occurrences": 11
+      },
+      {
+        "word": "fathers",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 4
+      },
+      {
+        "word": "the",
+        "occurrence": 6,
+        "occurrences": 11
+      },
+      {
+        "word": "children",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 7,
+        "occurrences": 11
+      },
+      {
+        "word": "disobedient",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 3,
+        "occurrences": 4
+      },
+      {
+        "word": "the",
+        "occurrence": 8,
+        "occurrences": 11
+      },
+      {
+        "word": "wisdom",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 4,
+        "occurrences": 4
+      },
+      {
+        "word": "the",
+        "occurrence": 9,
+        "occurrences": 11
+      },
+      {
+        "word": "righteous",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 4,
+        "occurrences": 4
+      },
+      {
+        "word": "make",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "ready",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "the",
+        "occurrence": 10,
+        "occurrences": 11
+      },
+      {
+        "word": "Lord",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 10
+      },
+      {
+        "word": "people",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "prepared",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "18": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ζαχαρίας",
+            "strongs": "G21970",
+            "lemma": "Ζαχαρίας",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄγγελον",
+            "strongs": "G00320",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κατὰ",
+            "strongs": "G25960",
+            "lemma": "κατά",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τί",
+            "strongs": "G51010",
+            "lemma": "τίς",
+            "morph": "Gr,RT,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γνώσομαι",
+            "strongs": "G10970",
+            "lemma": "γινώσκω",
+            "morph": "Gr,V,IFM1,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦτο",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,RD,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐγὼ",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1N,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γάρ",
+            "strongs": "G10630",
+            "lemma": "γάρ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰμι",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IPA1,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρεσβύτης",
+            "strongs": "G42460",
+            "lemma": "πρεσβύτης",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γυνή",
+            "strongs": "G11350",
+            "lemma": "γυνή",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μου",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "προβεβηκυῖα",
+            "strongs": "G42600",
+            "lemma": "προβαίνω",
+            "morph": "Gr,V,PEA,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέραις",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῆς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Zechariah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "angel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "How",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "can",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "I",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "know",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "this",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "For",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "I",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "am",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "an",
+        "occurrence": 1,
+        "occurrences": 5
+      },
+      {
+        "word": "old",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "man",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "my",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "wife",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "very",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "old",
+        "occurrence": 2,
+        "occurrences": 2
+      }
+    ]
+  },
+  "19": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀποκριθεὶς",
+            "strongs": "G06110",
+            "lemma": "ἀποκρίνω",
+            "morph": "Gr,V,PAP,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄγγελος",
+            "strongs": "G00320",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῷ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐγώ",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1N,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰμι",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IPA1,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Γαβριὴλ",
+            "strongs": "G10430",
+            "lemma": "Γαβριήλ",
+            "morph": "Gr,N,,,,,NMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,NMS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παρεστηκὼς",
+            "strongs": "G39360",
+            "lemma": "παρίστημι",
+            "morph": "Gr,V,PEA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐνώπιον",
+            "strongs": "G17990",
+            "lemma": "ἐνώπιον",
+            "morph": "Gr,PI,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεοῦ",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπεστάλην",
+            "strongs": "G06490",
+            "lemma": "ἀποστέλλω",
+            "morph": "Gr,V,IAP1,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λαλῆσαι",
+            "strongs": "G29800",
+            "lemma": "λαλέω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σὲ",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2A,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 3,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εὐαγγελίσασθαί",
+            "strongs": "G20970",
+            "lemma": "εὐαγγελίζω",
+            "morph": "Gr,V,NAM,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σοι",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2D,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταῦτα",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,RD,,,,ANP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "The",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "angel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "answered",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "I",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "am",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Gabriel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "stands",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "presence",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "I",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "sent",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 4
+      },
+      {
+        "word": "speak",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 3,
+        "occurrences": 4
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "to",
+        "occurrence": 4,
+        "occurrences": 4
+      },
+      {
+        "word": "bring",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "this",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "good",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "news",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "20": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἰδοὺ",
+            "strongs": "G37080",
+            "lemma": "ὁράω",
+            "morph": "Gr,IDMAA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔσῃ",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IFM2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σιωπῶν",
+            "strongs": "G46230",
+            "lemma": "σιωπάω",
+            "morph": "Gr,V,PPA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μὴ",
+            "strongs": "G33610",
+            "lemma": "μή",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δυνάμενος",
+            "strongs": "G14100",
+            "lemma": "δύναμαι",
+            "morph": "Gr,V,PPM,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λαλῆσαι",
+            "strongs": "G29800",
+            "lemma": "λαλέω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄχρι",
+            "strongs": "G08910",
+            "lemma": "ἄχρι",
+            "morph": "Gr,PI,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἧς",
+            "strongs": "G37390",
+            "lemma": "ὅς",
+            "morph": "Gr,ED,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέρας",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γένηται",
+            "strongs": "G10960",
+            "lemma": "γίνομαι",
+            "morph": "Gr,V,SAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταῦτα",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,RD,,,,NNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀνθ’",
+            "strongs": "G04730",
+            "lemma": "ἀντί",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὧν",
+            "strongs": "G37390",
+            "lemma": "ὅς",
+            "morph": "Gr,RD,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὐκ",
+            "strongs": "G37560",
+            "lemma": "οὐ",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπίστευσας",
+            "strongs": "G41000",
+            "lemma": "πιστεύω",
+            "morph": "Gr,V,IAA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λόγοις",
+            "strongs": "G30560",
+            "lemma": "λόγος",
+            "morph": "Gr,N,,,,,DMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μου",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἵτινες",
+            "strongs": "G37480",
+            "lemma": "ὅστις",
+            "morph": "Gr,RR,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πληρωθήσονται",
+            "strongs": "G41370",
+            "lemma": "πληρόω",
+            "morph": "Gr,V,IFP3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καιρὸν",
+            "strongs": "G25400",
+            "lemma": "καιρός",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῶν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Behold",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "You",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "silent",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "unable",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "speak",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "until",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "day",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "these",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "things",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "take",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "place",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "This",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "because",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "did",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "not",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "believe",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "my",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "words",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "which",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "be",
+        "occurrence": 2,
+        "occurrences": 4
+      },
+      {
+        "word": "fulfilled",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "at",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "right",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "time",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "21": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἦν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λαὸς",
+            "strongs": "G29920",
+            "lemma": "λαός",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "προσδοκῶν",
+            "strongs": "G43280",
+            "lemma": "προσδοκάω",
+            "morph": "Gr,V,PPA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ζαχαρίαν",
+            "strongs": "G21970",
+            "lemma": "Ζαχαρίας",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐθαύμαζον",
+            "strongs": "G22960",
+            "lemma": "θαυμάζω",
+            "morph": "Gr,V,IIA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "χρονίζειν",
+            "strongs": "G55490",
+            "lemma": "χρονίζω",
+            "morph": "Gr,V,NPA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτόν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ναῷ",
+            "strongs": "G34850",
+            "lemma": "ναός",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Now",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "people",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "were",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "waiting",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Zechariah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "They",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "were",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "surprised",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "spending",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "so",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "much",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "time",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "temple",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "22": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἐξελθὼν",
+            "strongs": "G18310",
+            "lemma": "ἐξέρχομαι",
+            "morph": "Gr,V,PAA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὐκ",
+            "strongs": "G37560",
+            "lemma": "οὐ",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐδύνατο",
+            "strongs": "G14100",
+            "lemma": "δύναμαι",
+            "morph": "Gr,V,IIM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λαλῆσαι",
+            "strongs": "G29800",
+            "lemma": "λαλέω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῖς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DMP,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπέγνωσαν",
+            "strongs": "G19210",
+            "lemma": "ἐπιγινώσκω",
+            "morph": "Gr,V,IAA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὅτι",
+            "strongs": "G37540",
+            "lemma": "ὅτι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὀπτασίαν",
+            "strongs": "G37010",
+            "lemma": "ὀπτασία",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἑώρακεν",
+            "strongs": "G37080",
+            "lemma": "ὁράω",
+            "morph": "Gr,V,IEA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ναῷ",
+            "strongs": "G34850",
+            "lemma": "ναός",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτὸς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἦν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διανεύων",
+            "strongs": "G12690",
+            "lemma": "διανεύω",
+            "morph": "Gr,V,PPA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῖς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DMP,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 3,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διέμενεν",
+            "strongs": "G12650",
+            "lemma": "διαμένω",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κωφός",
+            "strongs": "G29740",
+            "lemma": "κωφός",
+            "morph": "Gr,NP,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "But",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "when",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 9
+      },
+      {
+        "word": "came",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "out",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 2,
+        "occurrences": 9
+      },
+      {
+        "word": "could",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "not",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "speak",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "them",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "They",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "realized",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 3,
+        "occurrences": 9
+      },
+      {
+        "word": "had",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "seen",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 10
+      },
+      {
+        "word": "vision",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "while",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 4,
+        "occurrences": 9
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "temple",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "kept",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "on",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "making",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "signs",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "them",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "remained",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "silent",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "23": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐγένετο",
+            "strongs": "G10960",
+            "lemma": "γίνομαι",
+            "morph": "Gr,V,IAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὡς",
+            "strongs": "G56130",
+            "lemma": "ὡς",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπλήσθησαν",
+            "strongs": "G41300",
+            "lemma": "πλήθω",
+            "morph": "Gr,V,IAP3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αἱ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέραι",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,NFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λειτουργίας",
+            "strongs": "G30090",
+            "lemma": "λειτουργία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπῆλθεν",
+            "strongs": "G05650",
+            "lemma": "ἀπέρχομαι",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἶκον",
+            "strongs": "G36240",
+            "lemma": "οἶκος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "It",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "came",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "about",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "when",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "days",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "service",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "were",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "over",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "went",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "house",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "24": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "μετὰ",
+            "strongs": "G33260",
+            "lemma": "μετά",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταύτας",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,ED,,,,AFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὰς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέρας",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,AFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "συνέλαβεν",
+            "strongs": "G48150",
+            "lemma": "συνλαμβάνω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἐλεισάβετ",
+            "strongs": "G16650",
+            "lemma": "Ἐλεισάβετ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γυνὴ",
+            "strongs": "G11350",
+            "lemma": "γυνή",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "περιέκρυβεν",
+            "strongs": "G40320",
+            "lemma": "περικρύβω",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἑαυτὴν",
+            "strongs": "G14380",
+            "lemma": "ἑαυτοῦ",
+            "morph": "Gr,RE,,,3AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μῆνας",
+            "strongs": "G33760",
+            "lemma": "μήν",
+            "morph": "Gr,N,,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πέντε",
+            "strongs": "G40020",
+            "lemma": "πέντε",
+            "morph": "Gr,EN,,,,AMPI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λέγουσα",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,PPA,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "After",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "these",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "days",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "wife",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Elizabeth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "conceived",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "five",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "months",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "she",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "kept",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "herself",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "hidden",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "She",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "25": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ὅτι",
+            "strongs": "G37540",
+            "lemma": "ὅτι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὕτως",
+            "strongs": "G37790",
+            "lemma": "οὕτως",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μοι",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1D,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πεποίηκεν",
+            "strongs": "G41600",
+            "lemma": "ποιέω",
+            "morph": "Gr,V,IEA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κύριος",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέραις",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αἷς",
+            "strongs": "G37390",
+            "lemma": "ὅς",
+            "morph": "Gr,RR,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπεῖδεν",
+            "strongs": "G18960",
+            "lemma": "ἐφοράω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀφελεῖν",
+            "strongs": "G08510",
+            "lemma": "ἀφαιρέω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὄνειδός",
+            "strongs": "G36810",
+            "lemma": "ὄνειδος",
+            "morph": "Gr,N,,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μου",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀνθρώποις",
+            "strongs": "G04440",
+            "lemma": "ἄνθρωπος",
+            "morph": "Gr,N,,,,,DMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "This",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "what",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "done",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "me",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "when",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "looked",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "at",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "me",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "favor",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "order",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "take",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "away",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "my",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "shame",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "before",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "people",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "26": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μηνὶ",
+            "strongs": "G33760",
+            "lemma": "μήν",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἕκτῳ",
+            "strongs": "G16230",
+            "lemma": "ἕκτος",
+            "morph": "Gr,EO,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπεστάλη",
+            "strongs": "G06490",
+            "lemma": "ἀποστέλλω",
+            "morph": "Gr,V,IAP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄγγελος",
+            "strongs": "G00320",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Γαβριὴλ",
+            "strongs": "G10430",
+            "lemma": "Γαβριήλ",
+            "morph": "Gr,N,,,,,NMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπὸ",
+            "strongs": "G05750",
+            "lemma": "ἀπό",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεοῦ",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πόλιν",
+            "strongs": "G41720",
+            "lemma": "πόλις",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Γαλιλαίας",
+            "strongs": "G10560",
+            "lemma": "Γαλιλαία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ᾗ",
+            "strongs": "G37390",
+            "lemma": "ὅς",
+            "morph": "Gr,RR,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὄνομα",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ναζαρὲτ",
+            "strongs": "G34780",
+            "lemma": "Ναζαρέτ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "In",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "sixth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "month",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "angel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Gabriel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "sent",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "from",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 8
+      },
+      {
+        "word": "city",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Galilee",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "named",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Nazareth",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "27": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παρθένον",
+            "strongs": "G39330",
+            "lemma": "παρθένος",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐμνηστευμένην",
+            "strongs": "G34230",
+            "lemma": "μνηστεύω",
+            "morph": "Gr,V,PEP,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀνδρὶ",
+            "strongs": "G04350",
+            "lemma": "ἀνήρ",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ᾧ",
+            "strongs": "G37390",
+            "lemma": "ὅς",
+            "morph": "Gr,RR,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὄνομα",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰωσὴφ",
+            "strongs": "G25010",
+            "lemma": "Ἰωσήφ",
+            "morph": "Gr,N,,,,,NMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐξ",
+            "strongs": "G15370",
+            "lemma": "ἐκ",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἴκου",
+            "strongs": "G36240",
+            "lemma": "οἶκος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Δαυεὶδ",
+            "strongs": "G11380",
+            "lemma": "Δαυείδ",
+            "morph": "Gr,N,,,,,GMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὄνομα",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παρθένου",
+            "strongs": "G39330",
+            "lemma": "παρθένος",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Μαριάμ",
+            "strongs": "G31370",
+            "lemma": "Μαριάμ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 11
+      },
+      {
+        "word": "virgin",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "engaged",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "a",
+        "occurrence": 2,
+        "occurrences": 11
+      },
+      {
+        "word": "man",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "whose",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "name",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "Joseph",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "belonged",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "house",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "David",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "virgin",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "s",
+        "occurrence": 1,
+        "occurrences": 6
+      },
+      {
+        "word": "name",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "was",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "Mary",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "28": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰσελθὼν",
+            "strongs": "G15250",
+            "lemma": "εἰσέρχομαι",
+            "morph": "Gr,V,PAA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτὴν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄγγελος",
+            "strongs": "G00320",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "χαῖρε",
+            "strongs": "G54630",
+            "lemma": "χαίρω",
+            "morph": "Gr,IEMPA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κεχαριτωμένη",
+            "strongs": "G54870",
+            "lemma": "χαριτόω",
+            "morph": "Gr,V,PEP,VFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κύριος",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μετὰ",
+            "strongs": "G33260",
+            "lemma": "μετά",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σοῦ",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "came",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Greetings",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "are",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "highly",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "favored",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "The",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 2,
+        "occurrences": 2
+      }
+    ]
+  },
+  "29": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RP,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπὶ",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λόγῳ",
+            "strongs": "G30560",
+            "lemma": "λόγος",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διεταράχθη",
+            "strongs": "G12980",
+            "lemma": "διαταράσσω",
+            "morph": "Gr,V,IAP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διελογίζετο",
+            "strongs": "G12600",
+            "lemma": "διαλογίζομαι",
+            "morph": "Gr,V,IIM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ποταπὸς",
+            "strongs": "G42170",
+            "lemma": "ποταπός",
+            "morph": "Gr,RT,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἴη",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,OPA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀσπασμὸς",
+            "strongs": "G07830",
+            "lemma": "ἀσπασμός",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὗτος",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,ED,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "But",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "she",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "very",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "confused",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "by",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "words",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "she",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "wondered",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "what",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "kind",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "greeting",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "this",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "could",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "30": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄγγελος",
+            "strongs": "G00320",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῇ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μὴ",
+            "strongs": "G33610",
+            "lemma": "μή",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "φοβοῦ",
+            "strongs": "G53990",
+            "lemma": "φοβέω",
+            "morph": "Gr,V,MPM2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Μαριάμ",
+            "strongs": "G31370",
+            "lemma": "Μαριάμ",
+            "morph": "Gr,N,,,,,VFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εὗρες",
+            "strongs": "G21470",
+            "lemma": "εὑρίσκω",
+            "morph": "Gr,V,IAA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γὰρ",
+            "strongs": "G10630",
+            "lemma": "γάρ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "χάριν",
+            "strongs": "G54850",
+            "lemma": "χάρις",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παρὰ",
+            "strongs": "G38440",
+            "lemma": "παρά",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεῷ",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "The",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "angel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Do",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "not",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "afraid",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Mary",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "have",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "found",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "favor",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "31": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἰδοὺ",
+            "strongs": "G37080",
+            "lemma": "ὁράω",
+            "morph": "Gr,IDMAA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "συνλήμψῃ",
+            "strongs": "G48150",
+            "lemma": "συνλαμβάνω",
+            "morph": "Gr,V,IFM2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γαστρὶ",
+            "strongs": "G10640",
+            "lemma": "γαστήρ",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τέξῃ",
+            "strongs": "G50880",
+            "lemma": "τίκτω",
+            "morph": "Gr,V,IFM2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "υἱόν",
+            "strongs": "G52070",
+            "lemma": "υἱός",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 3,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καλέσεις",
+            "strongs": "G25640",
+            "lemma": "καλέω",
+            "morph": "Gr,V,IFA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὄνομα",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰησοῦν",
+            "strongs": "G24240",
+            "lemma": "Ἰησοῦς",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "See",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "conceive",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "your",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "womb",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "bear",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 5
+      },
+      {
+        "word": "son",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "You",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "call",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "name",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Jesus",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "32": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "οὗτος",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,RD,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔσται",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IFM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μέγας",
+            "strongs": "G31730",
+            "lemma": "μέγας",
+            "morph": "Gr,NP,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Υἱὸς",
+            "strongs": "G52070",
+            "lemma": "υἱός",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ὑψίστου",
+            "strongs": "G53100",
+            "lemma": "ὕψιστος",
+            "morph": "Gr,NS,,,,GMSS",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κληθήσεται",
+            "strongs": "G25640",
+            "lemma": "καλέω",
+            "morph": "Gr,V,IFP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δώσει",
+            "strongs": "G13250",
+            "lemma": "δίδωμι",
+            "morph": "Gr,V,IFA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῷ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κύριος",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεὸς",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "θρόνον",
+            "strongs": "G23620",
+            "lemma": "θρόνος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Δαυεὶδ",
+            "strongs": "G11380",
+            "lemma": "Δαυείδ",
+            "morph": "Gr,N,,,,,GMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πατρὸς",
+            "strongs": "G39620",
+            "lemma": "πατήρ",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "great",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "be",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "called",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "Son",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "Most",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "High",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "The",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "word": "give",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "word": "throne",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "ancestor",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "David",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "33": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "βασιλεύσει",
+            "strongs": "G09360",
+            "lemma": "βασιλεύω",
+            "morph": "Gr,V,IFA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπὶ",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἶκον",
+            "strongs": "G36240",
+            "lemma": "οἶκος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰακὼβ",
+            "strongs": "G23840",
+            "lemma": "Ἰακώβ",
+            "morph": "Gr,N,,,,,GMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοὺς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αἰῶνας",
+            "strongs": "G01650",
+            "lemma": "αἰών",
+            "morph": "Gr,N,,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "βασιλείας",
+            "strongs": "G09320",
+            "lemma": "βασιλεία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὐκ",
+            "strongs": "G37560",
+            "lemma": "οὐ",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔσται",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IFM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τέλος",
+            "strongs": "G50560",
+            "lemma": "τέλος",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "reign",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "over",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "house",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Jacob",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "forever",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "there",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "no",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "end",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "kingdom",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "34": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Μαριὰμ",
+            "strongs": "G31370",
+            "lemma": "Μαριάμ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄγγελον",
+            "strongs": "G00320",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πῶς",
+            "strongs": "G44590",
+            "lemma": "πῶς",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔσται",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IFM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦτο",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,RD,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπεὶ",
+            "strongs": "G18930",
+            "lemma": "ἐπεί",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄνδρα",
+            "strongs": "G04350",
+            "lemma": "ἀνήρ",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὐ",
+            "strongs": "G37560",
+            "lemma": "οὐ",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γινώσκω",
+            "strongs": "G10970",
+            "lemma": "γινώσκω",
+            "morph": "Gr,V,IPA1,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Mary",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "angel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "How",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "this",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "happen",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "since",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "I",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "have",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "not",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "slept",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "any",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "man",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "35": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀποκριθεὶς",
+            "strongs": "G06110",
+            "lemma": "ἀποκρίνω",
+            "morph": "Gr,V,PAP,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄγγελος",
+            "strongs": "G00320",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῇ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Πνεῦμα",
+            "strongs": "G41510",
+            "lemma": "πνεῦμα",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἅγιον",
+            "strongs": "G00400",
+            "lemma": "ἅγιος",
+            "morph": "Gr,AA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπελεύσεται",
+            "strongs": "G19040",
+            "lemma": "ἐπέρχομαι",
+            "morph": "Gr,V,IFM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπὶ",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σέ",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2A,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δύναμις",
+            "strongs": "G14110",
+            "lemma": "δύναμις",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ὑψίστου",
+            "strongs": "G53100",
+            "lemma": "ὕψιστος",
+            "morph": "Gr,NS,,,,GMSS",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπισκιάσει",
+            "strongs": "G19820",
+            "lemma": "ἐπισκιάζω",
+            "morph": "Gr,V,IFA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σοι",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2D,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διὸ",
+            "strongs": "G13520",
+            "lemma": "διό",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 3,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γεννώμενον",
+            "strongs": "G10800",
+            "lemma": "γεννάω",
+            "morph": "Gr,V,PPP,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἅγιον",
+            "strongs": "G00400",
+            "lemma": "ἅγιος",
+            "morph": "Gr,NS,,,,NNS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κληθήσεται",
+            "strongs": "G25640",
+            "lemma": "καλέω",
+            "morph": "Gr,V,IFP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Υἱὸς",
+            "strongs": "G52070",
+            "lemma": "υἱός",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεοῦ",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "The",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "angel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "answered",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "The",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "Holy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Spirit",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "come",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "upon",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "and",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "power",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 4
+      },
+      {
+        "word": "Most",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "High",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "come",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "over",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "So",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 3,
+        "occurrences": 4
+      },
+      {
+        "word": "holy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "one",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "born",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "word": "be",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "called",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 4,
+        "occurrences": 4
+      },
+      {
+        "word": "Son",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "36": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἰδοὺ",
+            "strongs": "G37080",
+            "lemma": "ὁράω",
+            "morph": "Gr,IDMAA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἐλεισάβετ",
+            "strongs": "G16650",
+            "lemma": "Ἐλεισάβετ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "συγγενίς",
+            "strongs": "G47735",
+            "lemma": "συγγενίς",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σου",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτὴ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "συνείληφεν",
+            "strongs": "G48150",
+            "lemma": "συνλαμβάνω",
+            "morph": "Gr,V,IEA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "υἱὸν",
+            "strongs": "G52070",
+            "lemma": "υἱός",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γήρει",
+            "strongs": "G10940",
+            "lemma": "γῆρας",
+            "morph": "Gr,N,,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῆς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 3,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὗτος",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,ED,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μὴν",
+            "strongs": "G33760",
+            "lemma": "μήν",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἕκτος",
+            "strongs": "G16230",
+            "lemma": "ἕκτος",
+            "morph": "Gr,EO,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐστὶν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IPA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῇ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RR,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καλουμένῃ",
+            "strongs": "G25640",
+            "lemma": "καλέω",
+            "morph": "Gr,V,PPP,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "στείρᾳ",
+            "strongs": "G47230",
+            "lemma": "στεῖρος",
+            "morph": "Gr,NP,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "See",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "your",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "relative",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Elizabeth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "also",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "conceived",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 9
+      },
+      {
+        "word": "son",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "old",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "age",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "This",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "sixth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "month",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "she",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "called",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "barren",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "37": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ὅτι",
+            "strongs": "G37540",
+            "lemma": "ὅτι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὐκ",
+            "strongs": "G37560",
+            "lemma": "οὐ",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀδυνατήσει",
+            "strongs": "G01010",
+            "lemma": "ἀδυνατέω",
+            "morph": "Gr,V,IFA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παρὰ",
+            "strongs": "G38440",
+            "lemma": "παρά",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεοῦ",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πᾶν",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,EQ,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ῥῆμα",
+            "strongs": "G44870",
+            "lemma": "ῥῆμα",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "For",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "nothing",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "impossible",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "38": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Μαριάμ",
+            "strongs": "G31370",
+            "lemma": "Μαριάμ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἰδοὺ",
+            "strongs": "G37080",
+            "lemma": "ὁράω",
+            "morph": "Gr,IDMAA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δούλη",
+            "strongs": "G13990",
+            "lemma": "δούλη",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κυρίου",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γένοιτό",
+            "strongs": "G10960",
+            "lemma": "γίνομαι",
+            "morph": "Gr,V,OAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μοι",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1D,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κατὰ",
+            "strongs": "G25960",
+            "lemma": "κατά",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ῥῆμά",
+            "strongs": "G44870",
+            "lemma": "ῥῆμα",
+            "morph": "Gr,N,,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σου",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπῆλθεν",
+            "strongs": "G05650",
+            "lemma": "ἀπέρχομαι",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπ’",
+            "strongs": "G05750",
+            "lemma": "ἀπό",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῆς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄγγελος",
+            "strongs": "G00320",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Mary",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "See",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "I",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "am",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "female",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "servant",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Let",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "it",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "me",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "according",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "your",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "message",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Then",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "word": "angel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "left",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "39": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἀναστᾶσα",
+            "strongs": "G04500",
+            "lemma": "ἀνίστημι",
+            "morph": "Gr,V,PAA,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Μαριὰμ",
+            "strongs": "G31370",
+            "lemma": "Μαριάμ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέραις",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταύταις",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,ED,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπορεύθη",
+            "strongs": "G41980",
+            "lemma": "πορεύω",
+            "morph": "Gr,V,IAP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὴν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὀρινὴν",
+            "strongs": "G37140",
+            "lemma": "ὀρινός",
+            "morph": "Gr,NS,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μετὰ",
+            "strongs": "G33260",
+            "lemma": "μετά",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σπουδῆς",
+            "strongs": "G47100",
+            "lemma": "σπουδή",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πόλιν",
+            "strongs": "G41720",
+            "lemma": "πόλις",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰούδα",
+            "strongs": "G24550",
+            "lemma": "Ἰούδας",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Then",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Mary",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "arose",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "those",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "days",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "quickly",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "went",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "into",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "hill",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "country",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 6
+      },
+      {
+        "word": "city",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "Judea",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "40": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰσῆλθεν",
+            "strongs": "G15250",
+            "lemma": "εἰσέρχομαι",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἶκον",
+            "strongs": "G36240",
+            "lemma": "οἶκος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ζαχαρίου",
+            "strongs": "G21970",
+            "lemma": "Ζαχαρίας",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἠσπάσατο",
+            "strongs": "G07820",
+            "lemma": "ἀσπάζομαι",
+            "morph": "Gr,V,IAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὴν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἐλεισάβετ",
+            "strongs": "G16650",
+            "lemma": "Ἐλεισάβετ",
+            "morph": "Gr,N,,,,,AFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "She",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "went",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "into",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "house",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Zechariah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "greeted",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Elizabeth",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "41": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐγένετο",
+            "strongs": "G10960",
+            "lemma": "γίνομαι",
+            "morph": "Gr,V,IAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὡς",
+            "strongs": "G56130",
+            "lemma": "ὡς",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἤκουσεν",
+            "strongs": "G01910",
+            "lemma": "ἀκούω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀσπασμὸν",
+            "strongs": "G07830",
+            "lemma": "ἀσπασμός",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Μαρίας",
+            "strongs": "G31370",
+            "lemma": "Μαρία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἐλεισάβετ",
+            "strongs": "G16650",
+            "lemma": "Ἐλεισάβετ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐσκίρτησεν",
+            "strongs": "G46400",
+            "lemma": "σκιρτάω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "βρέφος",
+            "strongs": "G10250",
+            "lemma": "βρέφος",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κοιλίᾳ",
+            "strongs": "G28360",
+            "lemma": "κοιλία",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῆς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπλήσθη",
+            "strongs": "G41300",
+            "lemma": "πλήθω",
+            "morph": "Gr,V,IAP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Πνεύματος",
+            "strongs": "G41510",
+            "lemma": "πνεῦμα",
+            "morph": "Gr,N,,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἁγίου",
+            "strongs": "G00400",
+            "lemma": "ἅγιος",
+            "morph": "Gr,AA,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἐλεισάβετ",
+            "strongs": "G16650",
+            "lemma": "Ἐλεισάβετ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Now",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "it",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "happened",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "when",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Elizabeth",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "heard",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Mary",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "s",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "greeting",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "baby",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "womb",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "jumped",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Elizabeth",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "filled",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "Holy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Spirit",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "42": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀνεφώνησεν",
+            "strongs": "G04000",
+            "lemma": "ἀναφωνέω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "φωνῇ",
+            "strongs": "G54560",
+            "lemma": "φωνή",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μεγάλῃ",
+            "strongs": "G31730",
+            "lemma": "μέγας",
+            "morph": "Gr,AA,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εὐλογημένη",
+            "strongs": "G21270",
+            "lemma": "εὐλογέω",
+            "morph": "Gr,V,PEP,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σὺ",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2N,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γυναιξίν",
+            "strongs": "G11350",
+            "lemma": "γυνή",
+            "morph": "Gr,N,,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 3,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εὐλογημένος",
+            "strongs": "G21270",
+            "lemma": "εὐλογέω",
+            "morph": "Gr,V,PEP,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καρπὸς",
+            "strongs": "G25900",
+            "lemma": "καρπός",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κοιλίας",
+            "strongs": "G28360",
+            "lemma": "κοιλία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σου",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "She",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "raised",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "voice",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "loudly",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Blessed",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "are",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "among",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "women",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "blessed",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "fruit",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "your",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "womb",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "43": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πόθεν",
+            "strongs": "G41590",
+            "lemma": "πόθεν",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μοι",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1D,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦτο",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,RD,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἵνα",
+            "strongs": "G24430",
+            "lemma": "ἵνα",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔλθῃ",
+            "strongs": "G20640",
+            "lemma": "ἔρχομαι",
+            "morph": "Gr,V,SAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μήτηρ",
+            "strongs": "G33840",
+            "lemma": "μήτηρ",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κυρίου",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μου",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐμέ",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1A,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Why",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "it",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "happened",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "me",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "mother",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "my",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "should",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "come",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "me",
+        "occurrence": 2,
+        "occurrences": 3
+      }
+    ]
+  },
+  "44": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἰδοὺ",
+            "strongs": "G37080",
+            "lemma": "ὁράω",
+            "morph": "Gr,IDMAA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γὰρ",
+            "strongs": "G10630",
+            "lemma": "γάρ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὡς",
+            "strongs": "G56130",
+            "lemma": "ὡς",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐγένετο",
+            "strongs": "G10960",
+            "lemma": "γίνομαι",
+            "morph": "Gr,V,IAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "φωνὴ",
+            "strongs": "G54560",
+            "lemma": "φωνή",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀσπασμοῦ",
+            "strongs": "G07830",
+            "lemma": "ἀσπασμός",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σου",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὰ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,ANP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὦτά",
+            "strongs": "G37750",
+            "lemma": "οὖς",
+            "morph": "Gr,N,,,,,ANP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μου",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,S,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐσκίρτησεν",
+            "strongs": "G46400",
+            "lemma": "σκιρτάω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀγαλλιάσει",
+            "strongs": "G00200",
+            "lemma": "ἀγαλλίασις",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "βρέφος",
+            "strongs": "G10250",
+            "lemma": "βρέφος",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κοιλίᾳ",
+            "strongs": "G28360",
+            "lemma": "κοιλία",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μου",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,S,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "For",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "see",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "when",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "sound",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "your",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "greeting",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "came",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "my",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "ears",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "baby",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "my",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "womb",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "jumped",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "joy",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "45": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μακαρία",
+            "strongs": "G31070",
+            "lemma": "μακάριος",
+            "morph": "Gr,NP,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πιστεύσασα",
+            "strongs": "G41000",
+            "lemma": "πιστεύω",
+            "morph": "Gr,V,PAA,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὅτι",
+            "strongs": "G37540",
+            "lemma": "ὅτι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔσται",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IFM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τελείωσις",
+            "strongs": "G50500",
+            "lemma": "τελείωσις",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,DNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λελαλημένοις",
+            "strongs": "G29800",
+            "lemma": "λαλέω",
+            "morph": "Gr,V,PEP,DNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῇ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παρὰ",
+            "strongs": "G38440",
+            "lemma": "παρά",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κυρίου",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Blessed",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "she",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "believed",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "there",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "would",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "fulfillment",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "things",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "were",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "told",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "from",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "46": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Μαριάμ",
+            "strongs": "G31370",
+            "lemma": "Μαριάμ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μεγαλύνει",
+            "strongs": "G31700",
+            "lemma": "μεγαλύνω",
+            "morph": "Gr,V,IPA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ψυχή",
+            "strongs": "G55900",
+            "lemma": "ψυχή",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μου",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κύριον",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Mary",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "47": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἠγαλλίασεν",
+            "strongs": "G00210",
+            "lemma": "ἀγαλλιάω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πνεῦμά",
+            "strongs": "G41510",
+            "lemma": "πνεῦμα",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μου",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,S,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπὶ",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεῷ",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Σωτῆρί",
+            "strongs": "G49900",
+            "lemma": "σωτήρ",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μου",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,S,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "my",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "spirit",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "rejoiced",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "my",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "savior",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "48": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ὅτι",
+            "strongs": "G37540",
+            "lemma": "ὅτι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπέβλεψεν",
+            "strongs": "G19140",
+            "lemma": "ἐπιβλέπω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπὶ",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὴν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταπείνωσιν",
+            "strongs": "G50140",
+            "lemma": "ταπείνωσις",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δούλης",
+            "strongs": "G13990",
+            "lemma": "δούλη",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἰδοὺ",
+            "strongs": "G37080",
+            "lemma": "ὁράω",
+            "morph": "Gr,IDMAA2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γὰρ",
+            "strongs": "G10630",
+            "lemma": "γάρ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπὸ",
+            "strongs": "G05750",
+            "lemma": "ἀπό",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "νῦν",
+            "strongs": "G35680",
+            "lemma": "νῦν",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μακαριοῦσίν",
+            "strongs": "G31060",
+            "lemma": "μακαρίζω",
+            "morph": "Gr,V,IFA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "με",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1A,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πᾶσαι",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,EQ,,,,NFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αἱ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γενεαί",
+            "strongs": "G10740",
+            "lemma": "γενεά",
+            "morph": "Gr,N,,,,,NFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "For",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "looked",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "at",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "low",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "condition",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "female",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "servant",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "49": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ὅτι",
+            "strongs": "G37540",
+            "lemma": "ὅτι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐποίησέν",
+            "strongs": "G41600",
+            "lemma": "ποιέω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μοι",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1D,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μεγάλα",
+            "strongs": "G31730",
+            "lemma": "μέγας",
+            "morph": "Gr,NS,,,,ANP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δυνατός",
+            "strongs": "G14150",
+            "lemma": "δυνατός",
+            "morph": "Gr,NS,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἅγιον",
+            "strongs": "G00400",
+            "lemma": "ἅγιος",
+            "morph": "Gr,NP,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὄνομα",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "For",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "mighty",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "done",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "great",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "things",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "me",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "50": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔλεος",
+            "strongs": "G16560",
+            "lemma": "ἔλεος",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γενεὰς",
+            "strongs": "G10740",
+            "lemma": "γενεά",
+            "morph": "Gr,N,,,,,AFP,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γενεὰς",
+            "strongs": "G10740",
+            "lemma": "γενεά",
+            "morph": "Gr,N,,,,,AFP,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,DMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "φοβουμένοις",
+            "strongs": "G53990",
+            "lemma": "φοβέω",
+            "morph": "Gr,V,PPM,DMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτόν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "His",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "mercy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "lasts",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "from",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "generation",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "generation",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "those",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "fear",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "51": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἐποίησεν",
+            "strongs": "G41600",
+            "lemma": "ποιέω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κράτος",
+            "strongs": "G29040",
+            "lemma": "κράτος",
+            "morph": "Gr,N,,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "βραχίονι",
+            "strongs": "G10230",
+            "lemma": "βραχίων",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διεσκόρπισεν",
+            "strongs": "G12870",
+            "lemma": "διασκορπίζω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὑπερηφάνους",
+            "strongs": "G52440",
+            "lemma": "ὑπερήφανος",
+            "morph": "Gr,NS,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διανοίᾳ",
+            "strongs": "G12710",
+            "lemma": "διάνοια",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καρδίας",
+            "strongs": "G25880",
+            "lemma": "καρδία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῶν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "displayed",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "strength",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "arm",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "52": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καθεῖλεν",
+            "strongs": "G25070",
+            "lemma": "καθαιρέω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δυνάστας",
+            "strongs": "G14130",
+            "lemma": "δυνάστης",
+            "morph": "Gr,N,,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπὸ",
+            "strongs": "G05750",
+            "lemma": "ἀπό",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "θρόνων",
+            "strongs": "G23620",
+            "lemma": "θρόνος",
+            "morph": "Gr,N,,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὕψωσεν",
+            "strongs": "G53120",
+            "lemma": "ὑψόω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταπεινούς",
+            "strongs": "G50110",
+            "lemma": "ταπεινός",
+            "morph": "Gr,NS,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "thrown",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "down",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "princes",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "from",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "their",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "thrones",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "53": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "πεινῶντας",
+            "strongs": "G39830",
+            "lemma": "πεινάω",
+            "morph": "Gr,V,PPA,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐνέπλησεν",
+            "strongs": "G17050",
+            "lemma": "ἐμπίπλημι",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀγαθῶν",
+            "strongs": "G00180",
+            "lemma": "ἀγαθός",
+            "morph": "Gr,NS,,,,GNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πλουτοῦντας",
+            "strongs": "G41470",
+            "lemma": "πλουτέω",
+            "morph": "Gr,V,PPA,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐξαπέστειλεν",
+            "strongs": "G18210",
+            "lemma": "ἐξαποστέλλω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κενούς",
+            "strongs": "G27560",
+            "lemma": "κενός",
+            "morph": "Gr,NS,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "filled",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "hungry",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "good",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "things",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "54": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἀντελάβετο",
+            "strongs": "G04820",
+            "lemma": "ἀντιλαμβάνω",
+            "morph": "Gr,V,IAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰσραὴλ",
+            "strongs": "G24740",
+            "lemma": "Ἰσραήλ",
+            "morph": "Gr,N,,,,,GMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παιδὸς",
+            "strongs": "G38160",
+            "lemma": "παῖς",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μνησθῆναι",
+            "strongs": "G34030",
+            "lemma": "μιμνῄσκω",
+            "morph": "Gr,V,NAP,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐλέους",
+            "strongs": "G16560",
+            "lemma": "ἔλεος",
+            "morph": "Gr,N,,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "given",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "help",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Israel",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "servant",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "55": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καθὼς",
+            "strongs": "G25310",
+            "lemma": "καθώς",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐλάλησεν",
+            "strongs": "G29800",
+            "lemma": "λαλέω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοὺς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πατέρας",
+            "strongs": "G39620",
+            "lemma": "πατήρ",
+            "morph": "Gr,N,,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῶν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἀβραὰμ",
+            "strongs": "G00110",
+            "lemma": "Ἀβραάμ",
+            "morph": "Gr,N,,,,,DMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DNS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σπέρματι",
+            "strongs": "G46900",
+            "lemma": "σπέρμα",
+            "morph": "Gr,N,,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αἰῶνα",
+            "strongs": "G01650",
+            "lemma": "αἰών",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "as",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "our",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "fathers",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "Abraham",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "descendants",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "forever",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "56": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἔμεινεν",
+            "strongs": "G33060",
+            "lemma": "μένω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Μαριὰμ",
+            "strongs": "G31370",
+            "lemma": "Μαριάμ",
+            "morph": "Gr,N,,,,,NFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σὺν",
+            "strongs": "G48620",
+            "lemma": "σύν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῇ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὡς",
+            "strongs": "G56130",
+            "lemma": "ὡς",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μῆνας",
+            "strongs": "G33760",
+            "lemma": "μήν",
+            "morph": "Gr,N,,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τρεῖς",
+            "strongs": "G51400",
+            "lemma": "τρεῖς",
+            "morph": "Gr,EN,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὑπέστρεψεν",
+            "strongs": "G52900",
+            "lemma": "ὑποστρέφω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἶκον",
+            "strongs": "G36240",
+            "lemma": "οἶκος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῆς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Mary",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "stayed",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Elizabeth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "about",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "three",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "months",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "then",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "returned",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "house",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "57": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἐλεισάβετ",
+            "strongs": "G16650",
+            "lemma": "Ἐλεισάβετ",
+            "morph": "Gr,N,,,,,DFSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπλήσθη",
+            "strongs": "G41300",
+            "lemma": "πλήθω",
+            "morph": "Gr,V,IAP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "χρόνος",
+            "strongs": "G55500",
+            "lemma": "χρόνος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τεκεῖν",
+            "strongs": "G50880",
+            "lemma": "τίκτω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτήν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐγέννησεν",
+            "strongs": "G10800",
+            "lemma": "γεννάω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "υἱόν",
+            "strongs": "G52070",
+            "lemma": "υἱός",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Now",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "time",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "had",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "come",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Elizabeth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "deliver",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "baby",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "she",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "gave",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "birth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 6
+      },
+      {
+        "word": "son",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "58": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἤκουσαν",
+            "strongs": "G01910",
+            "lemma": "ἀκούω",
+            "morph": "Gr,V,IAA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἱ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "περίοικοι",
+            "strongs": "G40400",
+            "lemma": "περίοικος",
+            "morph": "Gr,NS,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἱ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMP,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "συγγενεῖς",
+            "strongs": "G47730",
+            "lemma": "συγγενής",
+            "morph": "Gr,NS,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῆς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GFS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὅτι",
+            "strongs": "G37540",
+            "lemma": "ὅτι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐμεγάλυνεν",
+            "strongs": "G31700",
+            "lemma": "μεγαλύνω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κύριος",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔλεος",
+            "strongs": "G16560",
+            "lemma": "ἔλεος",
+            "morph": "Gr,N,,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μετ’",
+            "strongs": "G33260",
+            "lemma": "μετά",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῆς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GFS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 3,
+            "occurrences": 3
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "συνέχαιρον",
+            "strongs": "G47960",
+            "lemma": "συνχαίρω",
+            "morph": "Gr,V,IIA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῇ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Her",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "neighbors",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "relatives",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "heard",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "had",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "shown",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "great",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "mercy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "and",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "they",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "rejoiced",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 3,
+        "occurrences": 3
+      }
+    ]
+  },
+  "59": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐγένετο",
+            "strongs": "G10960",
+            "lemma": "γίνομαι",
+            "morph": "Gr,V,IAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέρᾳ",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὀγδόῃ",
+            "strongs": "G35900",
+            "lemma": "ὄγδοος",
+            "morph": "Gr,EO,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἦλθον",
+            "strongs": "G20640",
+            "lemma": "ἔρχομαι",
+            "morph": "Gr,V,IAA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "περιτεμεῖν",
+            "strongs": "G40590",
+            "lemma": "περιτέμνω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παιδίον",
+            "strongs": "G38130",
+            "lemma": "παιδίον",
+            "morph": "Gr,N,,,,,ANSD",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐκάλουν",
+            "strongs": "G25640",
+            "lemma": "καλέω",
+            "morph": "Gr,V,IIA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτὸ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπὶ",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὀνόματι",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πατρὸς",
+            "strongs": "G39620",
+            "lemma": "πατήρ",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ζαχαρίαν",
+            "strongs": "G21970",
+            "lemma": "Ζαχαρίας",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Now",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "it",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "happened",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "on",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 5
+      },
+      {
+        "word": "eighth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "day",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "they",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "came",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "circumcise",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 5
+      },
+      {
+        "word": "child",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "They",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "would",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "have",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "called",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Zechariah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "after",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 3,
+        "occurrences": 5
+      },
+      {
+        "word": "name",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "father",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "60": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀποκριθεῖσα",
+            "strongs": "G06110",
+            "lemma": "ἀποκρίνω",
+            "morph": "Gr,V,PAP,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μήτηρ",
+            "strongs": "G33840",
+            "lemma": "μήτηρ",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἶπεν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὐχί",
+            "strongs": "G37800",
+            "lemma": "οὐχί",
+            "morph": "Gr,IR,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀλλὰ",
+            "strongs": "G02350",
+            "lemma": "ἀλλά",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κληθήσεται",
+            "strongs": "G25640",
+            "lemma": "καλέω",
+            "morph": "Gr,V,IFP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰωάννης",
+            "strongs": "G24910",
+            "lemma": "Ἰωάννης",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "But",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "mother",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "answered",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "No",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "called",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "John",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "61": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἶπαν",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,IAA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτὴν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὅτι",
+            "strongs": "G37540",
+            "lemma": "ὅτι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οὐδείς",
+            "strongs": "G37620",
+            "lemma": "οὐδείς",
+            "morph": "Gr,RI,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐστιν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IPA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐκ",
+            "strongs": "G15370",
+            "lemma": "ἐκ",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "συγγενείας",
+            "strongs": "G47720",
+            "lemma": "συγγένεια",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σου",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2G,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὃς",
+            "strongs": "G37390",
+            "lemma": "ὅς",
+            "morph": "Gr,RR,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καλεῖται",
+            "strongs": "G25640",
+            "lemma": "καλέω",
+            "morph": "Gr,V,IPP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὀνόματι",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τούτῳ",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,ED,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "They",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "said",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "her",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "There",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "no",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "one",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "among",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "your",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "relatives",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "called",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "by",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "this",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "name",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "62": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἐνένευον",
+            "strongs": "G17700",
+            "lemma": "ἐννεύω",
+            "morph": "Gr,V,IIA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πατρὶ",
+            "strongs": "G39620",
+            "lemma": "πατήρ",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τί",
+            "strongs": "G51010",
+            "lemma": "τίς",
+            "morph": "Gr,RT,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἂν",
+            "strongs": "G03020",
+            "lemma": "ἄν",
+            "morph": "Gr,T,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "θέλοι",
+            "strongs": "G23090",
+            "lemma": "θέλω",
+            "morph": "Gr,V,OPA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καλεῖσθαι",
+            "strongs": "G25640",
+            "lemma": "καλέω",
+            "morph": "Gr,V,NPP,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτό",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "They",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "made",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "signs",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "father",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "as",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "how",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "wanted",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "named",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "63": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αἰτήσας",
+            "strongs": "G01540",
+            "lemma": "αἰτέω",
+            "morph": "Gr,V,PAA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πινακίδιον",
+            "strongs": "G40930",
+            "lemma": "πινακίδιον",
+            "morph": "Gr,N,,,,,ANSD",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔγραψεν",
+            "strongs": "G11250",
+            "lemma": "γράφω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λέγων",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,PPA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰωάννης",
+            "strongs": "G24910",
+            "lemma": "Ἰωάννης",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐστὶν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IPA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὄνομα",
+            "strongs": "G36860",
+            "lemma": "ὄνομα",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐθαύμασαν",
+            "strongs": "G22960",
+            "lemma": "θαυμάζω",
+            "morph": "Gr,V,IAA3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πάντες",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,RI,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "His",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "father",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "asked",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 9
+      },
+      {
+        "word": "writing",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "tablet",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "wrote",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "His",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "name",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "is",
+        "occurrence": 1,
+        "occurrences": 5
+      },
+      {
+        "word": "John",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "They",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "all",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "were",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "astonished",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "at",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "this",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "64": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἀνεῴχθη",
+            "strongs": "G04550",
+            "lemma": "ἀνεώγω",
+            "morph": "Gr,V,IAP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "στόμα",
+            "strongs": "G47500",
+            "lemma": "στόμα",
+            "morph": "Gr,N,,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παραχρῆμα",
+            "strongs": "G39160",
+            "lemma": "παραχρῆμα",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γλῶσσα",
+            "strongs": "G11000",
+            "lemma": "γλῶσσα",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐλάλει",
+            "strongs": "G29800",
+            "lemma": "λαλέω",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εὐλογῶν",
+            "strongs": "G21270",
+            "lemma": "εὐλογέω",
+            "morph": "Gr,V,PPA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεόν",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Immediately",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "mouth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "opened",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "his",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "tongue",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "freed",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "spoke",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "praised",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "65": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐγένετο",
+            "strongs": "G10960",
+            "lemma": "γίνομαι",
+            "morph": "Gr,V,IAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπὶ",
+            "strongs": "G19090",
+            "lemma": "ἐπί",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πάντας",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,RI,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "φόβος",
+            "strongs": "G54010",
+            "lemma": "φόβος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοὺς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "περιοικοῦντας",
+            "strongs": "G40390",
+            "lemma": "περιοικέω",
+            "morph": "Gr,V,PPA,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτούς",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὅλῃ",
+            "strongs": "G36500",
+            "lemma": "ὅλος",
+            "morph": "Gr,EQ,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὀρεινῇ",
+            "strongs": "G37140",
+            "lemma": "ὀρεινός",
+            "morph": "Gr,NS,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῆς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰουδαίας",
+            "strongs": "G24490",
+            "lemma": "Ἰουδαία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διελαλεῖτο",
+            "strongs": "G12550",
+            "lemma": "διαλαλέω",
+            "morph": "Gr,V,IIP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πάντα",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,EQ,,,,NNP,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὰ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ῥήματα",
+            "strongs": "G44870",
+            "lemma": "ῥῆμα",
+            "morph": "Gr,N,,,,,NNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταῦτα",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,ED,,,,NNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Fear",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "came",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "on",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "all",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "lived",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "around",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "them",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "All",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "these",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "matters",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "were",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "spread",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "throughout",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "all",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "hill",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "country",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Judea",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "66": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔθεντο",
+            "strongs": "G50870",
+            "lemma": "τίθημι",
+            "morph": "Gr,V,IAM3,,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πάντες",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,RI,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἱ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀκούσαντες",
+            "strongs": "G01910",
+            "lemma": "ἀκούω",
+            "morph": "Gr,V,PAA,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῇ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καρδίᾳ",
+            "strongs": "G25880",
+            "lemma": "καρδία",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῶν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λέγοντες",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,PPA,NMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τί",
+            "strongs": "G51010",
+            "lemma": "τίς",
+            "morph": "Gr,RT,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἄρα",
+            "strongs": "G06860",
+            "lemma": "ἄρα",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παιδίον",
+            "strongs": "G38130",
+            "lemma": "παιδίον",
+            "morph": "Gr,N,,,,,NNSD",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦτο",
+            "strongs": "G37780",
+            "lemma": "οὗτος",
+            "morph": "Gr,ED,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔσται",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IFM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γὰρ",
+            "strongs": "G10630",
+            "lemma": "γάρ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "χεὶρ",
+            "strongs": "G54950",
+            "lemma": "χείρ",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κυρίου",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἦν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μετ’",
+            "strongs": "G33260",
+            "lemma": "μετά",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "All",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "heard",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "them",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "stored",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "them",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "their",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "hearts",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "saying",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "What",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "then",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "this",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "child",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "become",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "For",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 6
+      },
+      {
+        "word": "hand",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 6
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "67": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ζαχαρίας",
+            "strongs": "G21970",
+            "lemma": "Ζαχαρίας",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πατὴρ",
+            "strongs": "G39620",
+            "lemma": "πατήρ",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπλήσθη",
+            "strongs": "G41300",
+            "lemma": "πλήθω",
+            "morph": "Gr,V,IAP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Πνεύματος",
+            "strongs": "G41510",
+            "lemma": "πνεῦμα",
+            "morph": "Gr,N,,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἁγίου",
+            "strongs": "G00400",
+            "lemma": "ἅγιος",
+            "morph": "Gr,AA,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπροφήτευσεν",
+            "strongs": "G43950",
+            "lemma": "προφητεύω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λέγων",
+            "strongs": "G30040",
+            "lemma": "λέγω",
+            "morph": "Gr,V,PPA,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "His",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "father",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Zechariah",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "filled",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "with",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "Holy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Spirit",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "prophesied",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "saying",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "68": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "εὐλογητὸς",
+            "strongs": "G21280",
+            "lemma": "εὐλογητός",
+            "morph": "Gr,NP,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κύριος",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεὸς",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰσραήλ",
+            "strongs": "G24740",
+            "lemma": "Ἰσραήλ",
+            "morph": "Gr,N,,,,,GMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὅτι",
+            "strongs": "G37540",
+            "lemma": "ὅτι",
+            "morph": "Gr,CS,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπεσκέψατο",
+            "strongs": "G19800",
+            "lemma": "ἐπισκέπτομαι",
+            "morph": "Gr,V,IAM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐποίησεν",
+            "strongs": "G41600",
+            "lemma": "ποιέω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λύτρωσιν",
+            "strongs": "G30850",
+            "lemma": "λύτρωσις",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λαῷ",
+            "strongs": "G29920",
+            "lemma": "λαός",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Praised",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "Lord",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Israel",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "69": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἤγειρεν",
+            "strongs": "G14530",
+            "lemma": "ἐγείρω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κέρας",
+            "strongs": "G27680",
+            "lemma": "κέρας",
+            "morph": "Gr,N,,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σωτηρίας",
+            "strongs": "G49910",
+            "lemma": "σωτηρία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῖν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1D,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἴκῳ",
+            "strongs": "G36240",
+            "lemma": "οἶκος",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Δαυεὶδ",
+            "strongs": "G11380",
+            "lemma": "Δαυείδ",
+            "morph": "Gr,N,,,,,GMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παιδὸς",
+            "strongs": "G38160",
+            "lemma": "παῖς",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "has",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "raised",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "up",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 5
+      },
+      {
+        "word": "horn",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "salvation",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "for",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "us",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "70": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καθὼς",
+            "strongs": "G25310",
+            "lemma": "καθώς",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐλάλησεν",
+            "strongs": "G29800",
+            "lemma": "λαλέω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διὰ",
+            "strongs": "G12230",
+            "lemma": "διά",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "στόματος",
+            "strongs": "G47500",
+            "lemma": "στόμα",
+            "morph": "Gr,N,,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῶν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἁγίων",
+            "strongs": "G00400",
+            "lemma": "ἅγιος",
+            "morph": "Gr,NS,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀπ’",
+            "strongs": "G05750",
+            "lemma": "ἀπό",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αἰῶνος",
+            "strongs": "G01650",
+            "lemma": "αἰών",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "προφητῶν",
+            "strongs": "G43960",
+            "lemma": "προφήτης",
+            "morph": "Gr,N,,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "as",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "spoke",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "by",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "mouth",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "holy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "prophets",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "from",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "long",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "ago",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "71": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "σωτηρίαν",
+            "strongs": "G49910",
+            "lemma": "σωτηρία",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐξ",
+            "strongs": "G15370",
+            "lemma": "ἐκ",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐχθρῶν",
+            "strongs": "G21900",
+            "lemma": "ἐχθρός",
+            "morph": "Gr,NS,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῶν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐκ",
+            "strongs": "G15370",
+            "lemma": "ἐκ",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "χειρὸς",
+            "strongs": "G54950",
+            "lemma": "χείρ",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πάντων",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,RI,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῶν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μισούντων",
+            "strongs": "G34040",
+            "lemma": "μισέω",
+            "morph": "Gr,V,PPA,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμᾶς",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1A,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "salvation",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "from",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "our",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "enemies",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "72": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ποιῆσαι",
+            "strongs": "G41600",
+            "lemma": "ποιέω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἔλεος",
+            "strongs": "G16560",
+            "lemma": "ἔλεος",
+            "morph": "Gr,N,,,,,ANS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μετὰ",
+            "strongs": "G33260",
+            "lemma": "μετά",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῶν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πατέρων",
+            "strongs": "G39620",
+            "lemma": "πατήρ",
+            "morph": "Gr,N,,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῶν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "μνησθῆναι",
+            "strongs": "G34030",
+            "lemma": "μιμνῄσκω",
+            "morph": "Gr,V,NAP,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "διαθήκης",
+            "strongs": "G12420",
+            "lemma": "διαθήκη",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἁγίας",
+            "strongs": "G00400",
+            "lemma": "ἅγιος",
+            "morph": "Gr,AA,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "do",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "this",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "show",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "mercy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "our",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "fathers",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "73": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ὅρκον",
+            "strongs": "G37270",
+            "lemma": "ὅρκος",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὃν",
+            "strongs": "G37390",
+            "lemma": "ὅς",
+            "morph": "Gr,RD,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὤμοσεν",
+            "strongs": "G36600",
+            "lemma": "ὀμνύω",
+            "morph": "Gr,V,IAA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἀβραὰμ",
+            "strongs": "G00110",
+            "lemma": "Ἀβραάμ",
+            "morph": "Gr,N,,,,,AMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πατέρα",
+            "strongs": "G39620",
+            "lemma": "πατήρ",
+            "morph": "Gr,N,,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῶν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δοῦναι",
+            "strongs": "G13250",
+            "lemma": "δίδωμι",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῖν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1D,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "oath",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "spoke",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Abraham",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "our",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "father",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "74": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἀφόβως",
+            "strongs": "G08700",
+            "lemma": "ἀφόβως",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐκ",
+            "strongs": "G15370",
+            "lemma": "ἐκ",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "χειρὸς",
+            "strongs": "G54950",
+            "lemma": "χείρ",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐχθρῶν",
+            "strongs": "G21900",
+            "lemma": "ἐχθρός",
+            "morph": "Gr,NS,,,,GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ῥυσθέντας",
+            "strongs": "G45060",
+            "lemma": "ῥύομαι",
+            "morph": "Gr,V,PAP,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λατρεύειν",
+            "strongs": "G30000",
+            "lemma": "λατρεύω",
+            "morph": "Gr,V,NPA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῷ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "He",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "swore",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "grant",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "us",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "that",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "we",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "having",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "been",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "delivered",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "out",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "hand",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "our",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "enemies",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "75": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁσιότητι",
+            "strongs": "G37420",
+            "lemma": "ὁσιότης",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δικαιοσύνῃ",
+            "strongs": "G13430",
+            "lemma": "δικαιοσύνη",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐνώπιον",
+            "strongs": "G17990",
+            "lemma": "ἐνώπιον",
+            "morph": "Gr,PI,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πάσαις",
+            "strongs": "G39560",
+            "lemma": "πᾶς",
+            "morph": "Gr,EQ,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέραις",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῶν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "holiness",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "righteousness",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "before",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "him",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "all",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "our",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "days",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "76": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,D,,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σὺ",
+            "strongs": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2N,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δέ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παιδίον",
+            "strongs": "G38130",
+            "lemma": "παιδίον",
+            "morph": "Gr,N,,,,,VNSD",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "προφήτης",
+            "strongs": "G43960",
+            "lemma": "προφήτης",
+            "morph": "Gr,N,,,,,NMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ὑψίστου",
+            "strongs": "G53100",
+            "lemma": "ὕψιστος",
+            "morph": "Gr,NS,,,,GMSS",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κληθήσῃ",
+            "strongs": "G25640",
+            "lemma": "καλέω",
+            "morph": "Gr,V,IFP2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "προπορεύσῃ",
+            "strongs": "G43130",
+            "lemma": "προπορεύομαι",
+            "morph": "Gr,V,IFM2,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γὰρ",
+            "strongs": "G10630",
+            "lemma": "γάρ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐνώπιον",
+            "strongs": "G17990",
+            "lemma": "ἐνώπιον",
+            "morph": "Gr,PI,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Κυρίου",
+            "strongs": "G29620",
+            "lemma": "κύριος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἑτοιμάσαι",
+            "strongs": "G20900",
+            "lemma": "ἑτοιμάζω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁδοὺς",
+            "strongs": "G35980",
+            "lemma": "ὁδός",
+            "morph": "Gr,N,,,,,AFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Yes",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "you",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "child",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "be",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "called",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "a",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "prophet",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Most",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "High",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "77": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δοῦναι",
+            "strongs": "G13250",
+            "lemma": "δίδωμι",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "γνῶσιν",
+            "strongs": "G11080",
+            "lemma": "γνῶσις",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σωτηρίας",
+            "strongs": "G49910",
+            "lemma": "σωτηρία",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τῷ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "λαῷ",
+            "strongs": "G29920",
+            "lemma": "λαός",
+            "morph": "Gr,N,,,,,DMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀφέσει",
+            "strongs": "G08590",
+            "lemma": "ἄφεσις",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἁμαρτιῶν",
+            "strongs": "G02660",
+            "lemma": "ἁμαρτία",
+            "morph": "Gr,N,,,,,GFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτῶν",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "give",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "knowledge",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "salvation",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "people",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "78": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "διὰ",
+            "strongs": "G12230",
+            "lemma": "διά",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σπλάγχνα",
+            "strongs": "G46980",
+            "lemma": "σπλάγχνον",
+            "morph": "Gr,N,,,,,ANP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐλέους",
+            "strongs": "G16560",
+            "lemma": "ἔλεος",
+            "morph": "Gr,N,,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Θεοῦ",
+            "strongs": "G23160",
+            "lemma": "θεός",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῶν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "οἷς",
+            "strongs": "G37390",
+            "lemma": "ὅς",
+            "morph": "Gr,RR,,,,DNP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐπισκέψεται",
+            "strongs": "G19800",
+            "lemma": "ἐπισκέπτομαι",
+            "morph": "Gr,V,IFM3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμᾶς",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1A,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀνατολὴ",
+            "strongs": "G03950",
+            "lemma": "ἀνατολή",
+            "morph": "Gr,N,,,,,NFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐξ",
+            "strongs": "G15370",
+            "lemma": "ἐκ",
+            "morph": "Gr,P,,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὕψους",
+            "strongs": "G53110",
+            "lemma": "ὕψος",
+            "morph": "Gr,N,,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "This",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "will",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "happen",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "because",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "tender",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "mercy",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "our",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "God",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "79": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "ἐπιφᾶναι",
+            "strongs": "G20140",
+            "lemma": "ἐπιφαίνω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,DMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σκότει",
+            "strongs": "G46550",
+            "lemma": "σκότος",
+            "morph": "Gr,N,,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "σκιᾷ",
+            "strongs": "G46390",
+            "lemma": "σκιά",
+            "morph": "Gr,N,,,,,DFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "θανάτου",
+            "strongs": "G22880",
+            "lemma": "θάνατος",
+            "morph": "Gr,N,,,,,GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καθημένοις",
+            "strongs": "G25210",
+            "lemma": "κάθημαι",
+            "morph": "Gr,V,PPM,DMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοῦ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,RD,,,,GNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "κατευθῦναι",
+            "strongs": "G27200",
+            "lemma": "κατευθύνω",
+            "morph": "Gr,V,NAA,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τοὺς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πόδας",
+            "strongs": "G42280",
+            "lemma": "πούς",
+            "morph": "Gr,N,,,,,AMP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμῶν",
+            "strongs": "G14730",
+            "lemma": "ἐγώ",
+            "morph": "Gr,RP,,,1G,P,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰς",
+            "strongs": "G15190",
+            "lemma": "εἰς",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ὁδὸν",
+            "strongs": "G35980",
+            "lemma": "ὁδός",
+            "morph": "Gr,N,,,,,AFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "εἰρήνης",
+            "strongs": "G15150",
+            "lemma": "εἰρήνη",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "shine",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "on",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "those",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "who",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "sit",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "darkness",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "shadow",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "death",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  },
+  "80": {
+    "alignments": [
+      {
+        "topWords": [
+          {
+            "word": "τὸ",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,NNS,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "δὲ",
+            "strongs": "G11610",
+            "lemma": "δέ",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "παιδίον",
+            "strongs": "G38130",
+            "lemma": "παιδίον",
+            "morph": "Gr,N,,,,,NNSD",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ηὔξανε",
+            "strongs": "G08370",
+            "lemma": "αὐξάνω",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 1,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐκραταιοῦτο",
+            "strongs": "G29010",
+            "lemma": "κραταιόω",
+            "morph": "Gr,V,IIP3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πνεύματι",
+            "strongs": "G41510",
+            "lemma": "πνεῦμα",
+            "morph": "Gr,N,,,,,DNS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "καὶ",
+            "strongs": "G25320",
+            "lemma": "καί",
+            "morph": "Gr,CC,,,,,,,,",
+            "occurrence": 2,
+            "occurrences": 2
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἦν",
+            "strongs": "G15100",
+            "lemma": "εἰμί",
+            "morph": "Gr,V,IIA3,,S,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strongs": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ταῖς",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἐρήμοις",
+            "strongs": "G20480",
+            "lemma": "ἔρημος",
+            "morph": "Gr,NS,,,,DFP,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἕως",
+            "strongs": "G21930",
+            "lemma": "ἕως",
+            "morph": "Gr,PI,,,,G,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἡμέρας",
+            "strongs": "G22500",
+            "lemma": "ἡμέρα",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "ἀναδείξεως",
+            "strongs": "G03230",
+            "lemma": "ἀνάδειξις",
+            "morph": "Gr,N,,,,,GFS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "αὐτοῦ",
+            "strongs": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "πρὸς",
+            "strongs": "G43140",
+            "lemma": "πρός",
+            "morph": "Gr,P,,,,,A,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "τὸν",
+            "strongs": "G35880",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,AMS,",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      },
+      {
+        "topWords": [
+          {
+            "word": "Ἰσραήλ",
+            "strongs": "G24740",
+            "lemma": "Ἰσραήλ",
+            "morph": "Gr,N,,,,,AMSI",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "bottomWords": []
+      }
+    ],
+    "wordBank": [
+      {
+        "word": "Now",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "word": "child",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "grew",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "became",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "strong",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "word": "spirit",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "and",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "he",
+        "occurrence": 1,
+        "occurrences": 4
+      },
+      {
+        "word": "was",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "in",
+        "occurrence": 2,
+        "occurrences": 2
+      },
+      {
+        "word": "the",
+        "occurrence": 2,
+        "occurrences": 3
+      },
+      {
+        "word": "wilderness",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "until",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "the",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "word": "day",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "of",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "his",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "public",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "appearance",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "to",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "word": "Israel",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7310,6 +7310,29 @@
         "lodash": "4.17.4"
       }
     },
+    "react-dnd-test-backend": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/react-dnd-test-backend/-/react-dnd-test-backend-2.5.4.tgz",
+      "integrity": "sha512-x9C59FnOo4XjDbWUXIp/dawtuiBsJa6DqMsy+4O/cphEn/7V5JklXkEn5fQr9h0hSk1w8jQJaKHbr2e2CsnFMg==",
+      "dev": true,
+      "requires": {
+        "dnd-core": "2.5.4"
+      },
+      "dependencies": {
+        "dnd-core": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.5.4.tgz",
+          "integrity": "sha512-BcI782MfTm3wCxeIS5c7tAutyTwEIANtuu3W6/xkoJRwiqhRXKX3BbGlycUxxyzMsKdvvoavxgrC3EMPFNYL9A==",
+          "dev": true,
+          "requires": {
+            "asap": "2.0.6",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4",
+            "redux": "3.7.2"
+          }
+        }
+      }
+    },
     "react-dom": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3341,6 +3341,12 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -3459,6 +3465,30 @@
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "supports-color": "4.4.0"
+      }
+    },
+    "cheerio": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+      "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash.assignin": "4.2.0",
+        "lodash.bind": "4.2.1",
+        "lodash.defaults": "4.2.0",
+        "lodash.filter": "4.6.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.foreach": "4.5.0",
+        "lodash.map": "4.6.0",
+        "lodash.merge": "4.6.0",
+        "lodash.pick": "4.4.0",
+        "lodash.reduce": "4.6.0",
+        "lodash.reject": "4.6.0",
+        "lodash.some": "4.6.0"
       }
     },
     "ci-info": {
@@ -3627,6 +3657,24 @@
         }
       }
     },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+      "dev": true
+    },
     "cssom": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
@@ -3753,6 +3801,49 @@
         "isarray": "1.0.0"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -3775,6 +3866,30 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "0.4.19"
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
+    },
+    "enzyme": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.9.1.tgz",
+      "integrity": "sha1-B9XOaRJBJA+4F78sSxjW5TAkDfY=",
+      "dev": true,
+      "requires": {
+        "cheerio": "0.22.0",
+        "function.prototype.name": "1.0.3",
+        "is-subset": "0.1.1",
+        "lodash": "4.17.4",
+        "object-is": "1.0.1",
+        "object.assign": "4.1.0",
+        "object.entries": "1.0.4",
+        "object.values": "1.0.4",
+        "prop-types": "15.5.10",
+        "uuid": "3.1.0"
       }
     },
     "errno": {
@@ -4258,11 +4373,926 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "function.prototype.name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
+      "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "is-callable": "1.1.3"
+      }
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -4425,6 +5455,12 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
@@ -4471,6 +5507,20 @@
       "dev": true,
       "requires": {
         "whatwg-encoding": "1.0.1"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.5.1",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
       }
     },
     "http-signature": {
@@ -4719,6 +5769,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -5532,6 +6588,78 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
       "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
     },
+    "lodash.assignin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+      "dev": true
+    },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "dev": true
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=",
+      "dev": true
+    },
+    "lodash.reject": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
+      "dev": true
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+      "dev": true
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -5658,6 +6786,13 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true,
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5721,6 +6856,15 @@
         "path-key": "2.0.1"
       }
     },
+    "nth-check": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -5744,11 +6888,41 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.2",
+        "function-bind": "1.1.1",
+        "has": "1.0.1"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
@@ -5758,6 +6932,18 @@
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
+      }
+    },
+    "object.values": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+      "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.2",
+        "function-bind": "1.1.1",
+        "has": "1.0.1"
       }
     },
     "once": {
@@ -6458,6 +7644,7 @@
         "anymatch": "1.3.2",
         "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
+        "fsevents": "1.1.3",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -6601,15 +7788,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -6628,6 +7806,15 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-env": "^1.6.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "enzyme": "^2.9.1",
     "eslint": "^4.7.2",
     "eslint-plugin-react": "^7.4.0",
     "jest": "^21.1.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint": "^4.7.2",
     "eslint-plugin-react": "^7.4.0",
     "jest": "^21.1.0",
+    "react-dnd-test-backend": "^2.5.4",
     "react-test-renderer": "^15.6.1"
   },
   "dependencies": {

--- a/src/components/DropBoxArea/index.js
+++ b/src/components/DropBoxArea/index.js
@@ -20,7 +20,8 @@ class DropBoxArea extends Component {
       return <div />;
     }
     const { chapter, verse } = contextId.reference;
-    const alignments = wordAlignmentReducer.alignmentData[chapter][verse].alignments;
+    const alignmentData = wordAlignmentReducer.alignmentData;
+    const alignments = alignmentData && alignmentData[chapter] && alignmentData[chapter][verse] ? alignmentData[chapter][verse].alignments : [];
     return (
       <div id='DropBoxArea' style={{ display: 'flex', flexWrap: 'wrap', height: '100%', backgroundColor: '#ffffff', padding: '0px 10px 50px', overflowY: 'auto' }}>
         {

--- a/src/components/WordBankArea/index.js
+++ b/src/components/WordBankArea/index.js
@@ -17,7 +17,8 @@ const WordBankArea = ({
     const {alignmentData} = wordAlignmentReducer;
     let wordBank = [];
     if (alignmentData[chapter] && alignmentData[chapter][verse]) {
-      wordBank = wordAlignmentReducer.alignmentData[chapter][verse].wordBank;
+      wordBank = alignmentData && alignmentData[chapter] && alignmentData[chapter][verse] ?
+        alignmentData[chapter][verse].wordBank : [];
     }
 
     return connectDropTarget(


### PR DESCRIPTION
#### This pull request addresses:

Issue: https://github.com/unfoldingWord-dev/translationCore/issues/3486

Fixes:
DropBoxArea/index.js & WordBankArea/index.js - fixes for verses without alignment data

#### How to test this pull request:

Needs to be tested with PR: https://github.com/unfoldingWord-dev/translationCore/pull/3492

#### Note: All tests were already failing in previous commit because they were not completed.  I have added 4 tests that are succeeding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-alignment-tool/14)
<!-- Reviewable:end -->
