### PR TITLE
Only scroll to top when changing verses not the opposite.

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -12,7 +12,7 @@ class Container extends Component {
   componentWillMount() {
     // current panes persisted in the scripture pane settings.
     let panes = this.props.settingsReducer.toolsSettings.ScripturePane.currentPaneSettings;
-    // filter out targetLanguage and bhp 
+    // filter out targetLanguage and bhp
     panes = panes.filter((pane) => {
       return pane !== "targetLanguage" && pane !== "bhp";
     });
@@ -27,7 +27,7 @@ class Container extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if(isEqual(this.props.contextIdReducer.contextId, nextProps.contextIdReducer.contextId)) {
+    if(!isEqual(this.props.contextIdReducer.contextId, nextProps.contextIdReducer.contextId)) {
       var page = document.getElementById("DropBoxArea");
       if (page) page.scrollTop = 0;
     }


### PR DESCRIPTION
## This PR addresses:

Scroll bug when aligning words at the bottom after scrolling down, its scrolled to the top.

## To Test this PR:

- Scrolling to the top was happening while aligning words in the same verse.
- Try finding multiple verses that you can scroll down with.
- Align words at the bottom and they shouldn't scroll to the top.
- Switch to another verse that can scroll, and it shouldn't stay scrolled down to the bottom and scrolls back to the top like it should.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-alignment-tool/15)
<!-- Reviewable:end -->
