### PR TITLE
Fixes word alignment tool on fresh install, no scripture pane settings

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -11,7 +11,9 @@ class Container extends Component {
 
   componentWillMount() {
     // current panes persisted in the scripture pane settings.
-    let panes = this.props.settingsReducer.toolsSettings.ScripturePane.currentPaneSettings;
+    const {ScripturePane} = this.props.settingsReducer.toolsSettings;
+    let panes = [];
+    if (ScripturePane) panes = ScripturePane.currentPaneSettings;
     // filter out targetLanguage and bhp
     panes = panes.filter((pane) => {
       return pane !== "targetLanguage" && pane !== "bhp";


### PR DESCRIPTION
This PR Addresses:

- Word Alignment tool will not open on fresh install
- Scripture Pane settings didn't exist and need to check before using them.

To Test:

BEFORE YOU CHECK OUT THE BRANCH:
- Nuke your `~/Library/Application Settings/translationCore` folder and launch tC.
- Load any project, then load word alignment tool, it should crash with the warning that "Cannot read property 'currentPaneSettings' of undefined"
- Ensure that tool doesn't load and presents you with the tools page with console error.

DO NOT CONTINUE UNTIL YOU CAN RECREATE THE ABOVE!

AFTER YOU CHECK OUT THE BRANCH:
- Repeat the above and errors should be gone, tool should load properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-alignment-tool/16)
<!-- Reviewable:end -->
